### PR TITLE
Bake in stats file at build time

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "flow:coverage": "flow-coverage-report report",
     "flow": "npm run flow:check && npm run flow:annotations && npm run flow:coverage",
     "start": "react-scripts start",
+    "start:with-stats": "REACT_APP_STATS_URL=https://pinterest.github.io/bonsai/example.json react-scripts start",
     "storybook": "start-storybook -p 9006 --dont-track",
     "build-storybook": "build-storybook --dont-track",
     "test": "npm run flow && react-scripts test --env=jsdom",

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -4,7 +4,7 @@
 
 import type {RawStats} from '../types/Stats';
 
-import FileInputRow from './FileInputRow';
+import FileInputContainer from './FileInputContainer';
 import Navbar from './Navbar';
 import React, { Component } from 'react';
 import Stats from './Stats';
@@ -31,7 +31,7 @@ export default class App extends Component<void, {}, State> {
         <div className="AppFixed">
           <div className="AppView">
             <aside className="container-fluid">
-              <FileInputRow
+              <FileInputContainer
                 filename={this.state.filename}
                 onLoading={this.onLoading}
                 onLoaded={this.onLoaded}

--- a/src/components/FileInputContainer.js
+++ b/src/components/FileInputContainer.js
@@ -1,0 +1,126 @@
+/*
+ * @flow
+ */
+
+import DragDropUpload from './DragDropUpload';
+import FileInputRow from './FileInputRow';
+import React, { Component } from 'react';
+
+type Props = {
+  filename: ?string,
+  onLoading: () => void,
+  onLoaded: (filename: ?string, stats: ?Object) => void,
+};
+
+type State = {
+  dataPaths: ?Array<string>,
+  isDragging: boolean,
+};
+
+function fetchJSON(
+  endpoint: string,
+  callback: (endpoint: string, json: Object) => void
+) {
+  return fetch(endpoint).then((response) => {
+    return response.json();
+  }).then((json) => {
+    callback(endpoint, json);
+  });
+}
+
+export default class FileInputContainer extends Component<void, Props, State> {
+  state: State = {
+    dataPaths: null,
+    isDragging: false,
+  };
+
+  constructor(props: Props) {
+    super(props);
+
+    this.loadPath(process.env.REACT_APP_STATS_URL || null);
+  }
+
+  componentDidMount() {
+    const endpoint = process.env.REACT_APP_API_LIST_ENDPOINT;
+    if (!endpoint) {
+      console.info('Env var \'REACT_APP_API_LIST_ENDPOINT\' was empty. Skipping fetch.');
+      return;
+    }
+    if (process.env.NODE_ENV === 'test') {
+      console.info('NODE_ENV is \'test\'. Skipping fetchJSON() in FileInputRow::componentDidMount');
+      return;
+    }
+
+    fetchJSON(endpoint, (fileName, json) => {
+      if (!json.paths) {
+        console.error(`Missing field. '${endpoint}' should return '{"paths": []}' key. Got: ${String(Object.keys(json))}`);
+      } else if (!Array.isArray(json.paths)) {
+        console.error('Invalid type: `paths`. Expected `paths` to be an array of web urls. Got:', json.paths);
+      } else {
+        this.setState({
+          dataPaths: json.paths.map(String),
+        });
+      }
+    }).catch((error) => {
+      console.error(`Failed while fetching json from '${endpoint}'.`, error);
+    });
+  }
+
+  render() {
+    return (
+      <div className="row">
+        <div className="col-sm-12">
+          <DragDropUpload
+            id="drag-drop-upload"
+            aria-describedby="drag-drop-helpblock"
+            className="form-control"
+            onDragEnter={() => this.setState({ isDragging: true })}
+            onDragLeave={() => this.setState({ isDragging: false })}
+            onLoading={this.onLoading}
+            onChange={this.onStatsFileUploaded}>
+            <FileInputRow
+              filename={this.props.filename}
+              dataPaths={this.state.dataPaths}
+              isDragging={this.state.isDragging}
+              onStatsFilePicked={this.loadPath}
+            />
+          </DragDropUpload>
+        </div>
+      </div>
+    );
+  }
+
+  onLoading = () => {
+    this.setState({
+      isDragging: false,
+    });
+    this.props.onLoading();
+  };
+
+  onStatsFileUploaded = (filename: string, fileText: string) => {
+    try {
+      const json = JSON.parse(fileText);
+      this.props.onLoaded(
+        filename,
+        json,
+      );
+    } catch (error) {
+      this.props.onLoaded(null, null);
+    }
+  };
+
+  loadPath = (path: string | null) => {
+    if (path) {
+      this.onLoading();
+      fetchJSON(path, (filename, json) => {
+        this.props.onLoaded(
+          filename,
+          json,
+        );
+      }).catch((error) => {
+        console.error(`Failed while fetching json from '${String(path)}'.`, error);
+        this.props.onLoaded(null, null);
+      });
+    }
+  };
+}

--- a/src/components/FileInputRow.js
+++ b/src/components/FileInputRow.js
@@ -2,183 +2,68 @@
  * @flow
  */
 
-import DragDropUpload from './DragDropUpload';
 import JsonFilePicker from './JsonFilePicker';
-import React, { Component } from 'react';
+import React from 'react';
 
 type Props = {
   filename: ?string,
-  onLoading: () => void,
-  onLoaded: (filename: ?string, stats: ?Object) => void,
-};
-
-type State = {
   dataPaths: ?Array<string>,
   isDragging: boolean,
+  onStatsFilePicked: (path: string | null) => void,
 };
 
-function fetchJSON(
-  endpoint: string,
-  callback: (endpoint: string, json: Object) => void
-) {
-  return fetch(endpoint).then((response) => {
-    return response.json();
-  }).then((json) => {
-    callback(endpoint, json);
-  });
-}
-
-export default class FileInputRow extends Component<void, Props, State> {
-  state: State = {
-    dataPaths: null,
-    isDragging: false,
-  };
-
-  constructor(props: Props) {
-    super(props);
-
-    this.loadPath(process.env.REACT_APP_STATS_URL || null);
-  }
-
-  componentDidMount() {
-    const endpoint = process.env.REACT_APP_API_LIST_ENDPOINT;
-    if (!endpoint) {
-      console.info('Env var \'REACT_APP_API_LIST_ENDPOINT\' was empty. Skipping fetch.');
-      return;
-    }
-    if (process.env.NODE_ENV === 'test') {
-      console.info('NODE_ENV is \'test\'. Skipping fetchJSON() in FileInputRow::componentDidMount');
-      return;
-    }
-
-    fetchJSON(endpoint, (fileName, json) => {
-      if (!json.paths) {
-        console.error(`Missing field. '${endpoint}' should return '{"paths": []}' key. Got: ${String(Object.keys(json))}`);
-      } else if (!Array.isArray(json.paths)) {
-        console.error('Invalid type: `paths`. Expected `paths` to be an array of web urls. Got:', json.paths);
-      } else {
-        this.setState({
-          dataPaths: json.paths.map(String),
-        });
-      }
-    }).catch((error) => {
-      console.error(`Failed while fetching json from '${endpoint}'.`, error);
-    });
-  }
-
-  render() {
+export default function FileInputRow(props: Props) {
+  if (props.filename) {
     return (
-      <div className="row">
-        <div className="col-sm-12">
-          <DragDropUpload
-            id="drag-drop-upload"
-            aria-describedby="drag-drop-helpblock"
-            className="form-control"
-            onDragEnter={() => this.setState({ isDragging: true })}
-            onDragLeave={() => this.setState({ isDragging: false })}
-            onLoading={this.onLoading}
-            onChange={this.onStatsFileUploaded}>
-            {this.renderFileInputRow(
-              this.props.filename,
-              this.state.isDragging,
-            )}
-          </DragDropUpload>
-        </div>
-      </div>
-    );
-  }
-
-  renderFileInputRow(filename: ?string, isDragging: boolean) {
-    if (filename) {
-      return (
-        <div className="form-horizontal">
-          <div className="form-group">
-            <label className="col-sm-1 control-label">Filename</label>
-            <div className="col-sm-11">
-              <p className="form-control-static">{filename}</p>
-            </div>
+      <div className="form-horizontal">
+        <div className="form-group">
+          <label className="col-sm-1 control-label">Filename</label>
+          <div className="col-sm-11">
+            <p className="form-control-static">{props.filename}</p>
           </div>
         </div>
-      );
-    }
-    return (
-      <div className="well well-sm clearfix">
-        <div className="form-horizontal">
-          {!filename || isDragging
-            ? <div className="form-group col-sm-6">
-                <label className="control-label">Drag & Drop your <code>stats.json</code> file here</label>
-                <span id="drag-drop-helpblock" className="col-sm-12 help-block">
-                  Run <kbd>webpack --json > stats.json</kbd> to get started.
-                </span>
-              </div>
-            : <div className="form-group col-sm-6">
-                <label className="col-sm-2 control-label">Loaded</label>
-                <div className="col-sm-10">
-                  <p className="form-control-static">{filename}</p>
-                </div>
-              </div>
-          }
-
-          {this.state.dataPaths
-            ? <div
-                className="form-group col-sm-6"
-                onClick={(event: SyntheticEvent) => event.stopPropagation() }>
-                <label className="col-sm-2 control-label" htmlFor="data-file-picker">File</label>
-                  <div className="col-sm-10">
-                    <JsonFilePicker
-                      id="data-file-picker"
-                      className="form-control"
-                      dataPaths={this.state.dataPaths}
-                      onChange={this.onStatsFilePicked}
-                    />
-                  </div>
-                {!filename || isDragging
-                  ? <span id="drag-drop-helpblock" className="col-sm-12 help-block">
-                      or pick an existing stats file.
-                    </span>
-                  : null}
-              </div>
-            : null}
-        </div>
       </div>
     );
   }
+  return (
+    <div className="well well-sm clearfix">
+      <div className="form-horizontal">
+        {!props.filename || props.isDragging
+          ? <div className="form-group col-sm-6">
+              <label className="control-label">Drag & Drop your <code>stats.json</code> file here</label>
+              <span id="drag-drop-helpblock" className="col-sm-12 help-block">
+                Run <kbd>webpack --json > stats.json</kbd> to get started.
+              </span>
+            </div>
+          : <div className="form-group col-sm-6">
+              <label className="col-sm-2 control-label">Loaded</label>
+              <div className="col-sm-10">
+                <p className="form-control-static">{props.filename}</p>
+              </div>
+            </div>
+        }
 
-  onLoading = () => {
-    this.setState({
-      isDragging: false,
-    });
-    this.props.onLoading();
-  };
-
-  onStatsFileUploaded = (filename: string, fileText: string) => {
-    try {
-      const json = JSON.parse(fileText);
-      this.props.onLoaded(
-        filename,
-        json,
-      );
-    } catch (error) {
-      this.props.onLoaded(null, null);
-    }
-  };
-
-  onStatsFilePicked = (event: SyntheticInputEvent) => {
-    this.loadPath(event.target.value);
-  };
-
-  loadPath(path: string | null): void {
-    if (path) {
-      this.onLoading();
-      fetchJSON(path, (filename, json) => {
-        this.props.onLoaded(
-          filename,
-          json,
-        );
-      }).catch((error) => {
-        console.error(`Failed while fetching json from '${String(path)}'.`, error);
-        this.props.onLoaded(null, null);
-      });
-    }
-  }
+        {props.dataPaths
+          ? <div
+              className="form-group col-sm-6"
+              onClick={(event: SyntheticEvent) => event.stopPropagation() }>
+              <label className="col-sm-2 control-label" htmlFor="data-file-picker">File</label>
+                <div className="col-sm-10">
+                  <JsonFilePicker
+                    id="data-file-picker"
+                    className="form-control"
+                    dataPaths={props.dataPaths}
+                    onChange={(event: SyntheticInputEvent) => props.onStatsFilePicked(event.target.value)}
+                  />
+                </div>
+              {!props.filename || props.isDragging
+                ? <span id="drag-drop-helpblock" className="col-sm-12 help-block">
+                    or pick an existing stats file.
+                  </span>
+                : null}
+            </div>
+          : null}
+      </div>
+    </div>
+  );
 }

--- a/src/components/FileInputRow.js
+++ b/src/components/FileInputRow.js
@@ -34,6 +34,12 @@ export default class FileInputRow extends Component<void, Props, State> {
     isDragging: false,
   };
 
+  constructor(props: Props) {
+    super(props);
+
+    this.loadPath(process.env.REACT_APP_STATS_URL || null);
+  }
+
   componentDidMount() {
     const endpoint = process.env.REACT_APP_API_LIST_ENDPOINT;
     if (!endpoint) {
@@ -158,7 +164,10 @@ export default class FileInputRow extends Component<void, Props, State> {
   };
 
   onStatsFilePicked = (event: SyntheticInputEvent) => {
-    const path = String(event.target.value);
+    this.loadPath(event.target.value);
+  };
+
+  loadPath(path: string | null): void {
     if (path) {
       this.onLoading();
       fetchJSON(path, (filename, json) => {
@@ -167,9 +176,9 @@ export default class FileInputRow extends Component<void, Props, State> {
           json,
         );
       }).catch((error) => {
-        console.error(`Failed while fetching json from '${path}'.`, error);
+        console.error(`Failed while fetching json from '${String(path)}'.`, error);
         this.props.onLoaded(null, null);
       });
     }
-  };
+  }
 }

--- a/src/components/__stories__/App.stories.js
+++ b/src/components/__stories__/App.stories.js
@@ -6,7 +6,7 @@ import React from 'react';
 import { storiesOf, action } from '@kadira/storybook';
 
 import App from '../App';
-import FileInputRow from '../FileInputRow';
+import FileInputContainer from '../FileInputContainer';
 import Stats from '../Stats';
 
 const stats = {
@@ -23,7 +23,7 @@ storiesOf('App', module)
   .add('FileInput stacked on Stats', () => (
     <div>
       <aside className="container-fluid">
-        <FileInputRow
+        <FileInputContainer
           filename={'stats.json'}
           onLoading={() => undefined}
           onLoaded={() => undefined}

--- a/src/components/__stories__/FileInputRow.stories.js
+++ b/src/components/__stories__/FileInputRow.stories.js
@@ -23,4 +23,20 @@ storiesOf('FileInputRow', module)
       isDragging={false}
       onStatsFilePicked={(path: string | null) => undefined}
     />
+  ))
+  .add('With dataPaths', () => (
+    <FileInputRow
+      filename={null}
+      dataPaths={['example.json']}
+      isDragging={false}
+      onStatsFilePicked={(path: string | null) => undefined}
+    />
+  ))
+  .add('With dataPaths and a file picked', () => (
+    <FileInputRow
+      filename={'stats.json'}
+      dataPaths={['example.json']}
+      isDragging={false}
+      onStatsFilePicked={(path: string | null) => undefined}
+    />
   ));

--- a/src/components/__stories__/FileInputRow.stories.js
+++ b/src/components/__stories__/FileInputRow.stories.js
@@ -11,14 +11,16 @@ storiesOf('FileInputRow', module)
   .add('No file', () => (
     <FileInputRow
       filename={null}
-      onLoading={() => undefined}
-      onLoaded={(s: ?string, o: ?Object) => undefined}
+      dataPaths={null}
+      isDragging={false}
+      onStatsFilePicked={(path: string | null) => undefined}
     />
   ))
   .add('File loaded', () => (
     <FileInputRow
       filename={'stats.json'}
-      onLoading={() => undefined}
-      onLoaded={(s: ?string, o: ?Object) => undefined}
+      dataPaths={null}
+      isDragging={false}
+      onStatsFilePicked={(path: string | null) => undefined}
     />
   ));

--- a/src/components/__tests__/__snapshots__/Storyshots.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Storyshots.test.js.snap
@@ -491,6 +491,83 @@ exports[`Storyshots FileInputRow No file 1`] = `
 </div>
 `;
 
+exports[`Storyshots FileInputRow With dataPaths 1`] = `
+<div
+  className="well well-sm clearfix">
+  <div
+    className="form-horizontal">
+    <div
+      className="form-group col-sm-6">
+      <label
+        className="control-label">
+        Drag & Drop your 
+        <code>
+          stats.json
+        </code>
+         file here
+      </label>
+      <span
+        className="col-sm-12 help-block"
+        id="drag-drop-helpblock">
+        Run 
+        <kbd>
+          webpack --json > stats.json
+        </kbd>
+         to get started.
+      </span>
+    </div>
+    <div
+      className="form-group col-sm-6"
+      onClick={[Function]}>
+      <label
+        className="col-sm-2 control-label"
+        htmlFor="data-file-picker">
+        File
+      </label>
+      <div
+        className="col-sm-10">
+        <select
+          className="form-control"
+          id="data-file-picker"
+          onChange={[Function]}>
+          <option
+            value="" />
+          <option
+            value="example.json">
+            example.json
+          </option>
+        </select>
+      </div>
+      <span
+        className="col-sm-12 help-block"
+        id="drag-drop-helpblock">
+        or pick an existing stats file.
+      </span>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots FileInputRow With dataPaths and a file picked 1`] = `
+<div
+  className="form-horizontal">
+  <div
+    className="form-group">
+    <label
+      className="col-sm-1 control-label">
+      Filename
+    </label>
+    <div
+      className="col-sm-11">
+      <p
+        className="form-control-static">
+        stats.json
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storyshots SortLabel Something else is sorted 1`] = `
 <div
   className="text-left">

--- a/src/components/__tests__/__snapshots__/Storyshots.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Storyshots.test.js.snap
@@ -444,39 +444,19 @@ exports[`Storyshots ExternalModuleLink No prefix 1`] = `null`;
 
 exports[`Storyshots FileInputRow File loaded 1`] = `
 <div
-  className="row">
+  className="form-horizontal">
   <div
-    className="col-sm-12">
+    className="form-group">
+    <label
+      className="col-sm-1 control-label">
+      Filename
+    </label>
     <div
-      onClick={[Function]}
-      style={undefined}>
-      <input
-        className="form-control"
-        id="drag-drop-upload"
-        onChange={[Function]}
-        style={
-          Object {
-            "display": "none",
-          }
-        }
-        type="file" />
-      <div
-        className="form-horizontal">
-        <div
-          className="form-group">
-          <label
-            className="col-sm-1 control-label">
-            Filename
-          </label>
-          <div
-            className="col-sm-11">
-            <p
-              className="form-control-static">
-              stats.json
-            </p>
-          </div>
-        </div>
-      </div>
+      className="col-sm-11">
+      <p
+        className="form-control-static">
+        stats.json
+      </p>
     </div>
   </div>
 </div>
@@ -484,48 +464,28 @@ exports[`Storyshots FileInputRow File loaded 1`] = `
 
 exports[`Storyshots FileInputRow No file 1`] = `
 <div
-  className="row">
+  className="well well-sm clearfix">
   <div
-    className="col-sm-12">
+    className="form-horizontal">
     <div
-      onClick={[Function]}
-      style={undefined}>
-      <input
-        className="form-control"
-        id="drag-drop-upload"
-        onChange={[Function]}
-        style={
-          Object {
-            "display": "none",
-          }
-        }
-        type="file" />
-      <div
-        className="well well-sm clearfix">
-        <div
-          className="form-horizontal">
-          <div
-            className="form-group col-sm-6">
-            <label
-              className="control-label">
-              Drag & Drop your 
-              <code>
-                stats.json
-              </code>
-               file here
-            </label>
-            <span
-              className="col-sm-12 help-block"
-              id="drag-drop-helpblock">
-              Run 
-              <kbd>
-                webpack --json > stats.json
-              </kbd>
-               to get started.
-            </span>
-          </div>
-        </div>
-      </div>
+      className="form-group col-sm-6">
+      <label
+        className="control-label">
+        Drag & Drop your 
+        <code>
+          stats.json
+        </code>
+         file here
+      </label>
+      <span
+        className="col-sm-12 help-block"
+        id="drag-drop-helpblock">
+        Run 
+        <kbd>
+          webpack --json > stats.json
+        </kbd>
+         to get started.
+      </span>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Instead of having to setup a server and all that json endpoint stuff, sometimes you just want to statically show one stats file, say after a deploy. Then on the next deploy rebuild the whole thing.

This adds a new env var called `REACT_APP_STATS_URL` which lets you bake-in a url where the stats file can be found, and it'll be fetched on page load.

The simplest way to use this env var is with a relative path and something like [`serve`](https://github.com/zeit/serve). It can be as easy as:

```bash
REACT_APP_STATS_URL=./stats.json npm run build
webpack --json $project_dir > build/stats.json
server build
```
Using REACT_APP_STATS_URL lets you go ahead and move the whole `build/` folder someplace else, tag it with the commit id, archive it, etc.
