### PR TITLE
indicating new yarn install instructions

### DIFF
--- a/index.md
+++ b/index.md
@@ -27,7 +27,7 @@ Once you clone Bonsai, it can run from your filesystem or anywhere you have a we
 ```
 git clone https://github.com/pinterest/bonsai.git
 cd bonsai && yarn install && yarn run build
-yarn install -g serve
+yarn global add serve
 serve ./build
 ```
 


### PR DESCRIPTION
When attempting to build Bonsai locally, a step in the [Running Bonsai](https://pinterest.github.io/bonsai/#running-bonsai) section of the GH pages indicates that users should install `serve` via the command: `yarn install -g serve`. A recent version of yarn changes how packages should be installed. I received this error message: `error `install` has been replaced with `add` to add new dependencies. Run "yarn global add serve" instead.`

The docs should indicate that users install `serve` via this command: `yarn global add serve`