### PR TITLE
Check against null, instead of truthiness to show ChunkBreadcrumb

### DIFF
--- a/src/components/stats/SelectedChunk.js
+++ b/src/components/stats/SelectedChunk.js
@@ -75,7 +75,7 @@ export default function SelectedChunk(props: Props) {
           />
         </div>
       </div>
-      {props.parentChunks && props.selectedChunkId
+      {props.parentChunks && props.selectedChunkId !== null && props.selectedChunkId !== undefined
         ? <div className="row">
             <div className="col-sm-11 col-sm-push-1">
               <ChunkBreadcrumb


### PR DESCRIPTION
Because chunks could be called `0`.