### PR TITLE
Switch to using module.name in the dependants&imports dropdowns

### DIFF
--- a/src/components/stats/ModulePanels.js
+++ b/src/components/stats/ModulePanels.js
@@ -28,7 +28,7 @@ export function RequiredByPanel({eModule}: {eModule: ExtendedModule}) {
               scrollToAndFocus(String(reason.moduleId));
             }}>
               <div className="text-left">
-                {formatModuleName(reason.moduleIdentifier)}
+                {formatModuleName(reason.moduleName)}
               </div>
             </Button>
           </li>
@@ -59,7 +59,7 @@ export function RequirementsPanel({eModule}: {eModule: ExtendedModule}) {
               scrollToAndFocus(String(module.id));
             }}>
               <div className="text-left">
-                {formatModuleName(module.identifier)}
+                {formatModuleName(module.name)}
               </div>
             </Button>
           </li>


### PR DESCRIPTION
This should make it much more readable because it'll always be about the same width as the first column, or less.