### PR TITLE
Explicitly test node version8 in travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 
 node_js:
   - node
+  - 8
   - 7
   - 6
 


### PR DESCRIPTION
We already test against node version8 with the `- node` line, but this calls it out before we hit v9