### PR TITLE
Clean built artifacts in the docs folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "build:prod": "NODE_ENV=production PUBLIC_URL=https://pinterest.github.io/bonsai/analyze/ REACT_APP_API_LIST_ENDPOINT=/bonsai/example-index.json REACT_APP_EXTERNAL_URL_PREFIX= yarn run build && mv build docs/analyze",
     "build:stats": "NODE_ENV=production ./node_modules/webpack/bin/webpack.js --json --config ./node_modules/react-scripts/config/webpack.config.prod.js > 'docs/example.json'",
     "build:storybook": "build-storybook -o 'docs/storybook'",
-    "clean": "rm -Rf npm-debug.log build lib coverage flow-coverage src/integration/tmp",
+    "clean": "rm -Rf npm-debug.log build lib coverage flow-coverage src/integration/tmp docs/analyze docs/storybook docs/example.json",
     "preversion": "npm run clean && npm run flow:build && npm run test && npm run build",
     "postversion": "git push && git push --tags && npm publish",
     "eject": "react-scripts eject"


### PR DESCRIPTION
These folders are already in the .gitignore list, but it's nice if everything that can be built can also be removed in dev.