### PR TITLE
Serialize picked file/chunk/removed-modules in url hash.

### DIFF
--- a/src/UrlStateEncoder.js
+++ b/src/UrlStateEncoder.js
@@ -1,0 +1,89 @@
+/**
+ * @flow
+ */
+
+import type { Store } from 'redux';
+import type { State } from './reducer';
+
+import {
+  PickedFile,
+  PickedChunk,
+  RemovedModule,
+} from './actions';
+
+type Subscription = () => void;
+
+function toQueryString(obj: Object): string {
+  return Object.keys(obj)
+    .map((key) => `${key}=${encodeURIComponent(obj[key])}`)
+    .join('&');
+}
+
+export default class UrlStateEncoder {
+  _store: Store<*, *>;
+  _subscription: ?Subscription = null;
+
+  static instance: ?UrlStateEncoder = null;
+  static factory = function(store: Store<*, *>): UrlStateEncoder {
+    if (!UrlStateEncoder.instance) {
+      UrlStateEncoder.instance = new UrlStateEncoder(store);
+    }
+    return UrlStateEncoder.instance;
+  }
+
+  constructor(store: Store<*, *>) {
+    this._store = store;
+
+    const targetState = this.readStateFromHash(window.location.hash);
+
+    if (targetState.filename !== null) {
+      PickedFile(store.dispatch)(targetState.filename);
+      if (targetState.chunk !== null) {
+        PickedChunk(store.dispatch)(targetState.chunk);
+        if (targetState.rm) {
+          const remove = RemovedModule(store.dispatch);
+          targetState.rm.split(',').forEach(remove);
+        }
+      }
+    }
+
+    this._subscription = store.subscribe(this.onStoreChanged);
+  }
+
+  onStoreChanged = () => {
+    const newState = this._store.getState();
+    console.log('new state', newState);
+    window.location.hash = this.encodeStateForHash(newState);
+  }
+
+  readStateFromHash(hash: string): Object {
+    return hash.replace(/^#/, '')
+      .split('&')
+      .reduce((map, pair) => {
+        const [key, val] = pair.split('=');
+        map[key] = decodeURIComponent(val);
+        return map;
+      }, {});
+  }
+
+  encodeStateForHash(state: State): string {
+    const vals = {};
+    if (state.selectedFilename !== null) {
+      vals.filename = state.selectedFilename;
+      if (state.selectedChunkId !== null) {
+        vals.chunk = state.selectedChunkId;
+        if (state.blacklistedModuleIds.length) {
+          vals.rm = state.blacklistedModuleIds.join(',');
+        }
+      }
+    }
+    return toQueryString(vals);
+  }
+
+  destroy() {
+    if (this._subscription) {
+      this._subscription();
+      this._subscription = null;
+    }
+  }
+}

--- a/src/components/stats/BlacklistTable.js
+++ b/src/components/stats/BlacklistTable.js
@@ -23,10 +23,10 @@ type Props = {
 
 export default function BlasklistTable(props: Props) {
   const blacklistedModulesList = props.blacklistedModulesIds.map(
-    (id) => props.removedModules.filter((module) => module.id === id),
+    (id) => props.removedModules.filter((module) => String(module.id) === String(id)),
   );
   const removedModules = props.removedModules.filter(
-    (module) => !props.blacklistedModulesIds.includes(module.id),
+    (module) => !props.blacklistedModulesIds.includes(String(module.id)),
   );
 
   const sum = props.removedModules.reduce(

--- a/src/components/stats/ChunkDropdown.js
+++ b/src/components/stats/ChunkDropdown.js
@@ -5,6 +5,7 @@
 import type {Child} from '../../stats/getEntryHeirarchy';
 import type {ChunkID} from '../../types/Stats';
 
+import { isSameChunk } from '../../types/Stats';
 import Button from '../Bootstrap/Button';
 import Dropdown from '../Bootstrap/Dropdown';
 import React from 'react';
@@ -24,7 +25,7 @@ export default function ChunkDropdown(props: Props) {
 
   function appendChildren(children: Array<Child>, indent: number) {
     children.forEach((child) => {
-      if (child.id === props.selectedChunkId) {
+      if (isSameChunk(child.id, props.selectedChunkId)) {
         selectedItem = {
           id: child.id,
           name: child.name,

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,8 @@ import handleAction from './reducer';
 import { createStore } from 'redux'
 import { Provider } from 'react-redux'
 
+import UrlStateEncoder from './UrlStateEncoder';
+
 import {
   InitDataPaths,
   PickedFile,
@@ -31,6 +33,8 @@ const store = createStore(
 if (process.env.REACT_APP_STATS_URL) {
   PickedFile(store.dispatch)(process.env.REACT_APP_STATS_URL);
 }
+
+UrlStateEncoder.factory(store);
 
 fetchApiListEndpoint(
   process.env.REACT_APP_API_LIST_ENDPOINT,

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -10,7 +10,6 @@ import type {
 } from './stats/filterModules';
 
 export type State = {
-  isLoading: boolean,
   dataPaths: Array<string>,
   selectedFilename: ?string,
   selectedChunkId: ?ChunkID,
@@ -62,7 +61,6 @@ export type Action =
 export type Dispatch = (action: Action) => any;
 
 export const INITIAL_STATE: State = {
-  isLoading: false,
   dataPaths: [],
   selectedFilename: null,
   selectedChunkId: null,
@@ -116,8 +114,6 @@ export default function handleAction(
     return {
       ...state,
       selectedFilename: action.filename,
-      selectedChunkId: null,
-      blacklistedModuleIds: [],
       dataPaths: concatItemToSet(state.dataPaths, action.filename),
       json: {
         ...state.json,
@@ -146,7 +142,7 @@ export default function handleAction(
   } else if (action.type === 'onPickedChunk') {
     return {
       ...state,
-      selectedChunkId: action.chunkId,
+      selectedChunkId: String(action.chunkId),
       blacklistedModuleIds: [],
     };
   } else if (action.type === 'onRemoveModule') {
@@ -162,7 +158,7 @@ export default function handleAction(
     return {
       ...state,
       blacklistedModuleIds: state.blacklistedModuleIds.filter(
-        (id) => id !== moduleID,
+        (id) => String(id) !== String(moduleID),
       ),
     };
   }

--- a/src/stats/getParentChunks.js
+++ b/src/stats/getParentChunks.js
@@ -3,9 +3,9 @@
  */
 
 import type {ChunkID} from '../types/Stats';
-
 import type {Child} from './getEntryHeirarchy';
 
+import {isSameChunk} from '../types/Stats';
 import {ROOT_ID} from './getEntryHeirarchy';
 
 function findChunk(
@@ -17,14 +17,14 @@ function findChunk(
     return null;
   }
 
-  if (root.id === targetID) {
+  if (isSameChunk(root.id, targetID)) {
     return history.concat(root);
   } else {
     for (let i = 0; i < root.children.length; i++) {
       const nextHistory = root.id !== ROOT_ID ? history.concat(root) : history;
       const found = findChunk(root.children[i], targetID, nextHistory);
       if (found) {
-          return found;
+        return found;
       }
     }
   }

--- a/src/stats/splitUnreachableModules.js
+++ b/src/stats/splitUnreachableModules.js
@@ -22,8 +22,8 @@ export default function splitUnreachableModules(
     };
   }
 
-  const moduleIds = modules.map((module) => module.id);
-  const _relevantReasons = (reason) => moduleIds.includes(reason.moduleId);
+  const moduleIds = modules.map((module) => String(module.id));
+  const _relevantReasons = (reason) => moduleIds.includes(String(reason.moduleId));
 
   const topLevelModules = modules.filter((module) => {
     return module.reasons.filter(_relevantReasons).length === 0;
@@ -32,14 +32,18 @@ export default function splitUnreachableModules(
   const reachableModuleIds: Set<ModuleID> = new Set();
   const recordChildModules = (modules: Array<ExtendedModule>) => {
     modules.forEach((module) => {
-      if (reachableModuleIds.has(module.id)) {
+      if (reachableModuleIds.has(String(module.id))) {
         return;
       }
 
       reachableModuleIds.add(module.id);
       recordChildModules(
         module.requirements
-          .filter((module) => !blacklistedModuleIds.includes(module.id))
+          .filter(
+            (module) => !blacklistedModuleIds
+              .map(String)
+              .includes(String(module.id))
+          )
           .map((module) => extendedModulesById[module.id])
       );
     });

--- a/src/types/Stats.js
+++ b/src/types/Stats.js
@@ -5,6 +5,14 @@
 export type ParsedJSON = any;
 
 export type ChunkID = string | number;
+export type ModuleID = string | number;
+
+export function isSameChunk(a: ?ChunkID, b: ?ChunkID): boolean {
+  if (a === null && b === null) {
+    return true;
+  }
+  return String(a) === String(b);
+}
 
 export type Asset = {
   name: string,
@@ -53,8 +61,6 @@ export type Chunk = {
   parents: Array<ChunkID>,
   origins: Array<Origin>
 };
-
-export type ModuleID = string | number;
 
 export type Module = {
   id: ModuleID,


### PR DESCRIPTION
Using the new redux actions and the store we can easily change state from any where in the app. So I've added a new module that serializes the picked modules into the current uri, and deserializes it on startup. This makes it possible to share views when the selected url is available (so when a server is used and provides a file from the network).

Addresses #41 