### PR TITLE
Stop printing extra <br/> tags at the end of formatModuleName

### DIFF
--- a/src/components/__tests__/__snapshots__/Storyshots.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Storyshots.test.js.snap
@@ -1211,7 +1211,6 @@ exports[`Storyshots formatModuleName delegated dll 1`] = `
   <span>
     delegated ./node_modules/classnames/index.js from dll-reference vendor
   </span>
-  <br />
 </span>
 `;
 
@@ -1233,7 +1232,6 @@ exports[`Storyshots formatModuleName loader 1`] = `
   >
     ./public/index.html
   </span>
-  <br />
 </span>
 `;
 
@@ -1255,7 +1253,6 @@ exports[`Storyshots formatModuleName loader with query 1`] = `
   >
     ./src/index.js
   </span>
-  <br />
 </span>
 `;
 
@@ -1277,7 +1274,6 @@ exports[`Storyshots formatModuleName main and loader with query 1`] = `
   >
     ./src/index.js
   </span>
-  <br />
 </span>
 `;
 
@@ -1290,7 +1286,6 @@ exports[`Storyshots formatModuleName multi 1`] = `
   <span>
     main
   </span>
-  <br />
 </span>
 `;
 
@@ -1299,7 +1294,6 @@ exports[`Storyshots formatModuleName node module 1`] = `
   <span>
     ./~/react-dev-utils/webpackHotDevClient.js
   </span>
-  <br />
 </span>
 `;
 
@@ -1308,6 +1302,5 @@ exports[`Storyshots formatModuleName plain filepath 1`] = `
   <span>
     components/stats/__stories__/formatModuleName.stories.js
   </span>
-  <br />
 </span>
 `;

--- a/src/components/stats/formatModuleName.js
+++ b/src/components/stats/formatModuleName.js
@@ -6,8 +6,12 @@ import React from 'react';
 
 const ELLIPSIS = '\u2026';
 
-function joinWithBR(nodes, label, index) {
-  return nodes.concat(label, <br key={index} />);
+function joinWithBR(nodes, label, index, values) {
+  if (index === values.length - 1) {
+    return nodes.concat(label);
+  } else {
+    return nodes.concat(label, <br key={index} />);
+  }
 }
 
 export default function formatModuleName(name: string) {


### PR DESCRIPTION
They didn't affect display because there was no following content, so lets rip them out.