### PR TITLE
`scrollToAndFocus` only scrolls when target is not in viewport

### DIFF
--- a/src/scrollToAndFocus.js
+++ b/src/scrollToAndFocus.js
@@ -62,15 +62,41 @@ function findPos(obj: HTMLElement) {
   return elem.offsetTop;
 }
 
+function isWithinViewport(
+  viewportTop: number,
+  viewportHeight: number,
+  targetTop: number,
+  targetHeight: number,
+): boolean {
+  return (
+    viewportTop < targetTop &&
+    targetTop < viewportTop + viewportHeight - targetHeight
+  );
+}
+
 export function scrollToElem(elem: HTMLElement) {
   const left = 0;
   const top = findPos(elem);
   const scrollParent = getScrollParent(elem);
   if (scrollParent) {
     if (scrollParent === document.body) {
-      window.scroll(left, top);
+      if (!isWithinViewport(
+        window.scrollY,
+        window.innerHeight,
+        top,
+        elem.offsetHeight,
+      )) {
+        window.scroll(left, top);
+      }
     } else {
-      scrollParent.scrollTop = top;
+      if (!isWithinViewport(
+        scrollParent.scrollTop,
+        scrollParent.offsetHeight,
+        top,
+        elem.offsetHeight,
+      )) {
+        scrollParent.scrollTop = top;
+      }
     }
   }
 }


### PR DESCRIPTION
This adds an `isWithinViewport` check to the existing behavior so we don't get scrolled around when we don't need to be.