### PR TITLE
Expand/Collapse improvements

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -109,6 +109,13 @@ export function IncludedModule(dispatch: Dispatch) {
   });
 }
 
+export function ChangeExpandMode(dispatch: Dispatch) {
+  return (mode: 'manual' | 'expand-all' | 'collapse-all') => dispatch({
+    type: 'changeExpandRecordsMode',
+    mode,
+  });
+}
+
 export function ExpandRecords(dispatch: Dispatch) {
   return (moduleID: ModuleID) => dispatch({
     type: 'onExpandRecords',

--- a/src/components/Bootstrap/Button.js
+++ b/src/components/Bootstrap/Button.js
@@ -86,12 +86,14 @@ export function Link(props: LinkProps) {
 
 type DropdownToggleProps = ButtonProps & {
   isOpen: boolean,
+  size?: Size,
 };
 
 export function DropdownToggleButton(props: DropdownToggleProps) {
   const classNames = [
     'btn',
     colorToClass('btn', props.color, 'default'),
+    sizeToClass(props.size),
     'dropdown-toggle',
   ].join(' ');
 

--- a/src/components/Bootstrap/Button.js
+++ b/src/components/Bootstrap/Button.js
@@ -70,7 +70,7 @@ export function Link(props: LinkProps) {
     'btn',
     colorToClass('btn', props.color, 'link'),
     sizeToClass(props.size),
-  ].join(' ');
+  ].filter(_ => _).join(' ');
 
   return (
     <a
@@ -95,7 +95,7 @@ export function DropdownToggleButton(props: DropdownToggleProps) {
     colorToClass('btn', props.color, 'default'),
     sizeToClass(props.size),
     'dropdown-toggle',
-  ].join(' ');
+  ].filter(_ => _).join(' ');
 
   return (
     <button

--- a/src/components/Bootstrap/Dropdown.js
+++ b/src/components/Bootstrap/Dropdown.js
@@ -11,9 +11,16 @@ import * as React from 'react';
 
 type Alignment = 'left' | 'right';
 
+type Size =
+  | 'lg'
+  | 'sm'
+  | 'xs'
+  | 'block';
+
 type Props = {
   align?: Alignment,
   color?: Color,
+  size?: Size,
   disabled?: boolean,
   style?: Object,
 
@@ -33,6 +40,13 @@ type Props = {
 type State = {
   isOpen: boolean,
 };
+
+function sizeToClass(size: ?Size) {
+  if (!size) {
+    return null;
+  }
+  return `btn-${size}`;
+}
 
 export default class Dropdown extends React.Component<Props, State> {
   state: State = {
@@ -54,12 +68,17 @@ export default class Dropdown extends React.Component<Props, State> {
     const isOpenClass = this.state.isOpen ? 'open': '';
     return (
       <div
-        className={['btn-group', isOpenClass].join(' ')}
+        className={[
+          'btn-group',
+          isOpenClass,
+          sizeToClass(this.props.size),
+        ].join(' ')}
         ref={(div) => this._dropDownMenu = div }
         style={this.props.style}>
         {this.props.split
           ? <Button
             color={this.props.color}
+            size={this.props.size}
             onClick={this.props.disabled
               ? null
               : this.props.split.primaryOnClick}>
@@ -68,6 +87,7 @@ export default class Dropdown extends React.Component<Props, State> {
           : null}
         <DropdownToggleButton
           color={this.props.color}
+          size={this.props.size}
           isOpen={this.state.isOpen}
           onClick={this.props.disabled
             ? null

--- a/src/components/Bootstrap/Dropdown.js
+++ b/src/components/Bootstrap/Dropdown.js
@@ -72,7 +72,7 @@ export default class Dropdown extends React.Component<Props, State> {
           'btn-group',
           isOpenClass,
           sizeToClass(this.props.size),
-        ].join(' ')}
+        ].filter(_ => _).join(' ')}
         ref={(div) => this._dropDownMenu = div }
         style={this.props.style}>
         {this.props.split
@@ -117,7 +117,7 @@ export default class Dropdown extends React.Component<Props, State> {
     const classNames = [
       'dropdown-menu',
       this.props.align === 'right' ? 'dropdown-menu-right' : '',
-    ].join(' ');
+    ].filter(_ => _).join(' ');
 
     const content = this.props.getContent(this.onHide);
     if (Array.isArray(content)) {

--- a/src/components/__tests__/__snapshots__/Storyshots.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Storyshots.test.js.snap
@@ -139,7 +139,7 @@ exports[`Storyshots App Filename picked, data available 1`] = `
                   className="col-sm-11"
                 >
                   <div
-                    className="btn-group "
+                    className="btn-group"
                     style={undefined}
                   >
                     <button
@@ -647,7 +647,7 @@ exports[`Storyshots BlacklistTable Module with no children removed 1`] = `
           className="vert-align numeric"
         >
           <div
-            className="btn-group "
+            className="btn-group"
             style={undefined}
           >
             <button
@@ -671,7 +671,7 @@ exports[`Storyshots BlacklistTable Module with no children removed 1`] = `
           className="vert-align numeric"
         >
           <div
-            className="btn-group "
+            className="btn-group"
             style={undefined}
           >
             <button
@@ -813,7 +813,7 @@ exports[`Storyshots BlacklistTable Module with some children removed 1`] = `
           className="vert-align numeric"
         >
           <div
-            className="btn-group "
+            className="btn-group"
             style={undefined}
           >
             <button
@@ -837,7 +837,7 @@ exports[`Storyshots BlacklistTable Module with some children removed 1`] = `
           className="vert-align numeric"
         >
           <div
-            className="btn-group "
+            className="btn-group"
             style={undefined}
           >
             <button
@@ -1063,7 +1063,7 @@ exports[`Storyshots Bootstrap/CloseButton With onClick 1`] = `
 
 exports[`Storyshots Bootstrap/Dropdown Basic 1`] = `
 <div
-  className="btn-group "
+  className="btn-group"
   style={undefined}
 >
   <button
@@ -1086,7 +1086,7 @@ exports[`Storyshots Bootstrap/Dropdown Basic 1`] = `
 
 exports[`Storyshots Bootstrap/Dropdown Basic Warning 1`] = `
 <div
-  className="btn-group "
+  className="btn-group"
   style={undefined}
 >
   <button
@@ -1109,7 +1109,7 @@ exports[`Storyshots Bootstrap/Dropdown Basic Warning 1`] = `
 
 exports[`Storyshots Bootstrap/Dropdown Basic align right 1`] = `
 <div
-  className="btn-group "
+  className="btn-group"
   style={undefined}
 >
   <button
@@ -1132,7 +1132,7 @@ exports[`Storyshots Bootstrap/Dropdown Basic align right 1`] = `
 
 exports[`Storyshots Bootstrap/Dropdown Basic custom style 1`] = `
 <div
-  className="btn-group "
+  className="btn-group"
   style={
     Object {
       "background": "red",
@@ -1160,7 +1160,7 @@ exports[`Storyshots Bootstrap/Dropdown Basic custom style 1`] = `
 
 exports[`Storyshots Bootstrap/Dropdown Basic disabled 1`] = `
 <div
-  className="btn-group "
+  className="btn-group"
   style={undefined}
 >
   <button
@@ -1183,7 +1183,7 @@ exports[`Storyshots Bootstrap/Dropdown Basic disabled 1`] = `
 
 exports[`Storyshots Bootstrap/Dropdown List Content 1`] = `
 <div
-  className="btn-group "
+  className="btn-group"
   style={undefined}
 >
   <button
@@ -1206,7 +1206,7 @@ exports[`Storyshots Bootstrap/Dropdown List Content 1`] = `
 
 exports[`Storyshots Bootstrap/Dropdown Split Button 1`] = `
 <div
-  className="btn-group "
+  className="btn-group"
   style={undefined}
 >
   <button
@@ -1242,7 +1242,7 @@ exports[`Storyshots Bootstrap/Dropdown Split Button 1`] = `
 
 exports[`Storyshots Bootstrap/Dropdown Split Button w/ Color 1`] = `
 <div
-  className="btn-group "
+  className="btn-group"
   style={undefined}
 >
   <button
@@ -1278,7 +1278,7 @@ exports[`Storyshots Bootstrap/Dropdown Split Button w/ Color 1`] = `
 
 exports[`Storyshots Bootstrap/Dropdown Split Button w/ Glyph 1`] = `
 <div
-  className="btn-group "
+  className="btn-group"
   style={undefined}
 >
   <button
@@ -1314,7 +1314,7 @@ exports[`Storyshots Bootstrap/Dropdown Split Button w/ Glyph 1`] = `
 
 exports[`Storyshots Bootstrap/Dropdown Split Button w/ List Content 1`] = `
 <div
-  className="btn-group "
+  className="btn-group"
   style={undefined}
 >
   <button
@@ -1350,7 +1350,7 @@ exports[`Storyshots Bootstrap/Dropdown Split Button w/ List Content 1`] = `
 
 exports[`Storyshots Bootstrap/Link Disabled 1`] = `
 <a
-  className="btn btn-link "
+  className="btn btn-link"
   disabled="disabled"
   href="#"
   role="button"
@@ -1362,7 +1362,7 @@ exports[`Storyshots Bootstrap/Link Disabled 1`] = `
 
 exports[`Storyshots Bootstrap/Link Disabled Success 1`] = `
 <a
-  className="btn btn-success "
+  className="btn btn-success"
   disabled="disabled"
   href="#"
   role="button"
@@ -1386,7 +1386,7 @@ exports[`Storyshots Bootstrap/Link Large 1`] = `
 
 exports[`Storyshots Bootstrap/Link Opens new tab 1`] = `
 <a
-  className="btn btn-link "
+  className="btn btn-link"
   disabled={null}
   href="example.com"
   role="button"
@@ -1401,7 +1401,7 @@ exports[`Storyshots Bootstrap/Link Opens new tab 1`] = `
 
 exports[`Storyshots Bootstrap/Link Success 1`] = `
 <a
-  className="btn btn-success "
+  className="btn btn-success"
   disabled={null}
   href="javascript: alert('Linked!');"
   role="button"
@@ -1413,7 +1413,7 @@ exports[`Storyshots Bootstrap/Link Success 1`] = `
 
 exports[`Storyshots Bootstrap/Link With href 1`] = `
 <a
-  className="btn btn-link "
+  className="btn btn-link"
   disabled={null}
   href="javascript: alert('Linked!');"
   role="button"
@@ -1733,7 +1733,7 @@ exports[`Storyshots Bootstrap/Panel With table child 1`] = `
 
 exports[`Storyshots ExternalModuleLink Default 1`] = `
 <a
-  className="btn btn-link "
+  className="btn btn-link"
   disabled={null}
   href="http://example.com/./app/analytics/modules/AnalyticsMetric/AnalyticsMetric.js"
   role="button"

--- a/src/components/stats/ModuleDataContainer.js
+++ b/src/components/stats/ModuleDataContainer.js
@@ -9,6 +9,7 @@ import * as React from 'react';
 import ModuleTableContainer from './ModuleTableContainer';
 import { connect } from 'react-redux';
 import Panel from '../Bootstrap/Panel';
+import ToggleExpandModeButton from './ToggleExpandModeButton';
 
 export type Props = {
   moduleData: ?{
@@ -23,9 +24,16 @@ function ModuleData(props: Props) {
     props.moduleData
       ? <Panel
         type='primary'
-        heading={`${props.moduleData.removed.length === 0
-          ? 'All'
-          : props.moduleData.included.length} Modules Included`}>
+        heading={(
+          <div>
+            <div className="pull-right">
+              <ToggleExpandModeButton />
+            </div>
+            {props.moduleData.removed.length === 0
+              ? 'All'
+              : props.moduleData.included.length} Modules Included
+          </div>
+        )}>
         <ModuleTableContainer
           extendedModules={props.extendedModules}
         />

--- a/src/components/stats/ModuleTable.js
+++ b/src/components/stats/ModuleTable.js
@@ -28,6 +28,7 @@ export type OwnProps = {
 export type StateProps = {
   filters: FilterProps,
   sort: SortProps,
+  expandMode: 'manual' | 'collapse-all' | 'expand-all',
   expandedRecords: Set<ModuleID>,
   focusedRowID: ?string,
 };
@@ -75,6 +76,7 @@ export default class ModuleTable extends Component<Props> {
         />
         <ModuleTableBody
           rows={rows}
+          expandMode={props.expandMode}
           expandedRecords={props.expandedRecords}
           onRemoveModule={props.onRemoveModule}
           onExpandRecords={props.onExpandRecords}

--- a/src/components/stats/ModuleTableBody.js
+++ b/src/components/stats/ModuleTableBody.js
@@ -126,7 +126,7 @@ function ModuleTableRow(props: TRProps) {
       {...OffsetPageAnchor(String(eModule.id), {
         className: [
           'ModuleTableBody-row',
-          props.expanded
+          props.expanded && props.records.length > 1
             ? 'ModuleTableBody-expanded-border'
             : null,
         ].join(' ').trim()

--- a/src/components/stats/ModuleTableBody.js
+++ b/src/components/stats/ModuleTableBody.js
@@ -25,6 +25,7 @@ import './ModuleTableBody.css';
 
 type TBodyProps = {
   rows: Array<RowRepresentation>,
+  expandMode: 'manual' | 'collapse-all' | 'expand-all',
   expandedRecords: Set<ModuleID>,
   onRemoveModule: (moduleID: ModuleID) => void,
   onExpandRecords: (moduleID: ModuleID) => void,
@@ -169,7 +170,8 @@ export default function ModuleTableBody(props: TBodyProps) {
       {flatten(
         props.rows.map((row: RowRepresentation) => ModuleTableGroupedRows({
           row: row,
-          expanded: props.expandedRecords.has(row.displayModule.id),
+          expanded: props.expandMode === 'expand-all' ||
+            (props.expandMode === 'manual' && props.expandedRecords.has(row.displayModule.id)),
           onRemoveModule: props.onRemoveModule,
           onExpandRecords: props.onExpandRecords,
           onCollapseRecords: props.onCollapseRecords,

--- a/src/components/stats/ModuleTableContainer.js
+++ b/src/components/stats/ModuleTableContainer.js
@@ -19,6 +19,7 @@ const mapStateToProps = (state: State): StateProps => {
   return {
     filters: state.filters,
     sort: state.sort,
+    expandMode: state.expandMode,
     expandedRecords: state.expandedRecords,
     focusedRowID: state.currentlyFocusedElementID,
   };

--- a/src/components/stats/ToggleExpandModeButton.js
+++ b/src/components/stats/ToggleExpandModeButton.js
@@ -1,0 +1,90 @@
+/*
+ * @flow
+ */
+
+import type { State } from '../../reducer';
+
+import Dropdown from '../Bootstrap/Dropdown';
+import { getClassName } from '../Bootstrap/GlyphiconNames';
+import * as React from 'react';
+import { connect } from 'react-redux';
+import {
+  ChangeExpandMode,
+} from '../../actions';
+
+type StateProps = {
+  expandMode: 'manual' | 'collapse-all' | 'expand-all',
+};
+
+type DispatchProps = {
+  onChangedExpandMode: (mode: 'manual' | 'collapse-all' | 'expand-all') => void,
+};
+
+export type Props = StateProps & DispatchProps;
+
+function ModeOption(props) {
+  const isSetToTarget = props.nextMode === props.expandMode;
+
+  return (
+    <li>
+      <a href="#" onClick={(e) => {
+        e.preventDefault();
+        props.onPickMode(props.nextMode);
+      }}>
+        <span className={getClassName(isSetToTarget ? 'check' : 'unchecked')} />
+        {' '}
+        {props.nextMode === 'expand-all' ? 'Expand' : 'Collapse'} All
+      </a>
+    </li>
+  );
+}
+
+function ToggleExpandModeButton(props: Props) {
+  return (
+    <Dropdown
+      align='right'
+      size='xs'
+      getContent={(hideContent) => {
+        const pickedMode = (mode) => {
+          hideContent();
+          props.onChangedExpandMode(mode);
+        };
+
+        return [
+          <ModeOption
+            key='expand-all'
+            expandMode={props.expandMode}
+            nextMode={'expand-all'}
+            onPickMode={pickedMode}
+          />,
+          <ModeOption
+            key='collapse-all'
+            expandMode={props.expandMode}
+            nextMode={'collapse-all'}
+            onPickMode={pickedMode}
+          />,
+        ];
+      }}>
+      Unqiue Imports
+      {' '}
+      <span className="caret"></span>
+    </Dropdown>
+  );
+}
+
+const mapStateToProps = (state: State): StateProps => {
+  return {
+    expandMode: state.expandMode,
+  };
+};
+
+const mapDispatchToProps = (dispatch: Dispatch): DispatchProps => {
+  return {
+    onChangedExpandMode: ChangeExpandMode(dispatch),
+  };
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(ToggleExpandModeButton);

--- a/src/components/stats/ToggleExpandModeButton.js
+++ b/src/components/stats/ToggleExpandModeButton.js
@@ -4,6 +4,7 @@
 
 import type { State } from '../../reducer';
 
+import Button from '../Bootstrap/Button';
 import Dropdown from '../Bootstrap/Dropdown';
 import { getClassName } from '../Bootstrap/GlyphiconNames';
 import * as React from 'react';
@@ -27,14 +28,14 @@ function ModeOption(props) {
 
   return (
     <li>
-      <a href="#" onClick={(e) => {
+      <Button onClick={(e) => {
         e.preventDefault();
         props.onPickMode(props.nextMode);
       }}>
         <span className={getClassName(isSetToTarget ? 'check' : 'unchecked')} />
         {' '}
         {props.nextMode === 'expand-all' ? 'Expand' : 'Collapse'} All
-      </a>
+      </Button>
     </li>
   );
 }


### PR DESCRIPTION
Adds a button to allow people to show&hide all the unique-import groups that are on the page. Useful for when you want to read all the module names, or ctrl+f over the page.