### PR TITLE
Fix possibility of null object in `getCollapsableParentOf` and add tests

### DIFF
--- a/src/stats/__tests__/getCollapsableParentOf.test.js
+++ b/src/stats/__tests__/getCollapsableParentOf.test.js
@@ -1,0 +1,103 @@
+/**
+ * @flow
+ */
+
+import getCollapsableParentOf from '../getCollapsableParentOf';
+import getExtendedModulesById from '../getExtendedModulesById';
+import {
+  defaultModule,
+  reasonFromModule,
+} from '../../__test_helpers__/defaults';
+
+const ENTRY_ZERO = defaultModule({
+  id: 0,
+  reasons: [],
+});
+
+const ENTRY_ONE = defaultModule({
+  id: 1,
+  reasons: [],
+});
+
+const ZERO_A = defaultModule({
+  id: 2,
+  reasons: [
+    reasonFromModule(ENTRY_ZERO),
+  ],
+});
+
+const COMMON = defaultModule({
+  id: 3,
+  reasons: [
+    reasonFromModule(ENTRY_ZERO),
+    reasonFromModule(ENTRY_ONE),
+  ],
+});
+
+const COMMON_UTIL = defaultModule({
+  id: 4,
+  reasons: [
+    reasonFromModule(COMMON),
+  ],
+});
+
+const BIG_MODULE = defaultModule({
+  id: 5,
+  reasons: [
+    reasonFromModule(ZERO_A),
+    reasonFromModule(COMMON),
+  ],
+});
+
+const ENTRY_ONE_A = defaultModule({
+  id: 600,
+  reasons: [
+    reasonFromModule(ENTRY_ONE),
+  ],
+});
+
+const ENTRY_ONE_B = defaultModule({
+  id: 300,
+  reasons: [
+    reasonFromModule(ENTRY_ONE_A),
+  ],
+});
+
+const MODULES = [
+  ENTRY_ZERO,
+  ENTRY_ONE,
+  ZERO_A,
+  COMMON,
+  COMMON_UTIL,
+  BIG_MODULE,
+  ENTRY_ONE_A,
+  ENTRY_ONE_B,
+];
+
+const modulesById = getExtendedModulesById(MODULES);
+
+describe('getCollapsableParentOf', () => {
+  it('should return null when the requested moduleid is not in the map', () => {
+    expect(getCollapsableParentOf(modulesById, 'foo')).toBeNull();
+  });
+
+  it('should return null when the requested module is not required by anything', () => {
+    expect(getCollapsableParentOf(modulesById, ENTRY_ZERO.id)).toBeNull();
+  });
+
+  it('should return null when many things require this, but it has no children', () => {
+    expect(getCollapsableParentOf(modulesById, BIG_MODULE.id)).toBeNull();
+  });
+
+  it('should be the collapsable parent when many things require this, and it has children', () => {
+    const collapsable = getCollapsableParentOf(modulesById, COMMON.id);
+    expect(collapsable).not.toBeNull();
+    expect(collapsable).toEqual(expect.objectContaining(COMMON));
+  });
+
+  it('should travel up to find the collapsable parent', () => {
+    const collapsable = getCollapsableParentOf(modulesById, COMMON_UTIL.id);
+    expect(collapsable).not.toBeNull();
+    expect(collapsable).toEqual(expect.objectContaining(COMMON));
+  });
+});

--- a/src/stats/getCollapsableParentOf.js
+++ b/src/stats/getCollapsableParentOf.js
@@ -3,22 +3,24 @@
  */
 
 import type {
+  ModuleID,
   ExtendedModule,
 } from '../types/Stats';
 import type { ExtendedModulesById } from './getModulesById';
 
 export default function getCollapsableParentOf(
   modulesById: ExtendedModulesById,
-  module: ExtendedModule,
+  moduleId: ModuleID,
 ): ?ExtendedModule {
+  const module = modulesById[moduleId];
+  if (!module) {
+    return null;
+  }
   const requiredByCount = module.requiredBy.length;
   if (requiredByCount === 0) {
     return null;
   } else if (requiredByCount === 1) {
-    const eModule = modulesById[module.requiredBy[0].moduleId];
-    return eModule
-      ? getCollapsableParentOf(modulesById, eModule)
-      : null;
+    return getCollapsableParentOf(modulesById, module.requiredBy[0].moduleId);
   } else {
     const requirementCount = module.requirements.length;
     if (requirementCount === 0) {

--- a/src/utils/reducer.js
+++ b/src/utils/reducer.js
@@ -255,7 +255,7 @@ function handleAction(
         const modulesById = getModulesById(state.calculatedFullModuleData.extendedModules);
         const collapseableParent = getCollapsableParentOf(
           modulesById,
-          modulesById[moduleId],
+          moduleId,
         );
         return {
           ...state,


### PR DESCRIPTION
Fixing #173 

That object lookup in `reducer.js` was going bad when I had weird things in the url bar I think. So we can move it inside `getCollapsableParentOf` and check it each time we recurse.