### PR TITLE
Fix storybook channel setup and redux HMR

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -11,8 +11,18 @@ function loadStories() {
   req.keys().forEach(req);
 }
 
+const store = createStore(handleAction);
+if (module.hot) {
+  // Enable Webpack hot module replacement for reducers
+  module.hot.accept('../src/utils/reducer', () => {
+    const nextRootReducer = require('../src/utils/reducer').default;
+    console.log('replacing with', nextRootReducer);
+    store.replaceReducer(nextRootReducer);
+  });
+}
+
 addDecorator((story) => (
-  <Provider store={createStore(handleAction)}>
+  <Provider store={store}>
     {story()}
   </Provider>
 ));

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "redux": "^3.7.0"
   },
   "devDependencies": {
-    "@storybook/addon-actions": "^3.2.6",
+    "@storybook/addon-actions": "3.2.16",
     "@storybook/addon-storyshots": "3.2.16",
     "@storybook/react": "3.2.16",
     "babel-eslint": "^8.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -58,22 +58,11 @@
   version "3.0.9"
   resolved "https://registry.yarnpkg.com/@hypnosphi/fuse.js/-/fuse.js-3.0.9.tgz#ea99f6121b4a8f065b4c71f85595db2714498807"
 
-"@storybook/addon-actions@^3.2.16":
+"@storybook/addon-actions@3.2.16", "@storybook/addon-actions@^3.2.16":
   version "3.2.16"
   resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-3.2.16.tgz#dc53d48dc8035b426a02628687c6cb0601b933b9"
   dependencies:
     "@storybook/addons" "^3.2.16"
-    deep-equal "^1.0.1"
-    json-stringify-safe "^5.0.1"
-    prop-types "^15.6.0"
-    react-inspector "^2.2.1"
-    uuid "^3.1.0"
-
-"@storybook/addon-actions@^3.2.6":
-  version "3.2.15"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-3.2.15.tgz#a54228d86baeb637adbbbdd11ff0c040d9862952"
-  dependencies:
-    "@storybook/addons" "^3.2.15"
     deep-equal "^1.0.1"
     json-stringify-safe "^5.0.1"
     prop-types "^15.6.0"
@@ -94,10 +83,6 @@
     global "^4.3.2"
     prop-types "^15.6.0"
     read-pkg-up "^3.0.0"
-
-"@storybook/addons@^3.2.15":
-  version "3.2.15"
-  resolved "https://registry.yarnpkg.com/@storybook/addons/-/addons-3.2.15.tgz#120fc3e34454b9e6c779f25b945d354511168abc"
 
 "@storybook/addons@^3.2.16":
   version "3.2.16"


### PR DESCRIPTION
The storybook channels were throwing in the console because there were different version of some addons installed, apparently yarn/greenkeeper were not locking versions the right way for storybook. I'll have to watch out for that better in the future.

Also, followed the redux instructions for HMR and got the storybook config doing the right thing for our <Provider>