### PR TITLE
Refactor multi-config logic into a new picker to support multi-config stats files.

### DIFF
--- a/src/cli/fileSystemHelper.js
+++ b/src/cli/fileSystemHelper.js
@@ -2,10 +2,12 @@
  * @flow
  */
 
+import type {RawStats} from '../types/Stats';
+
 import fs from 'fs';
 import getRawStats from '../types/getRawStats';
 
-export function openRawStatsFile(statsFilePath: string): * {
+export function openRawStatsFile(statsFilePath: string): Array<RawStats> {
   const data = JSON.parse(
     fs.readFileSync(statsFilePath, {encoding: 'utf8'})
   );

--- a/src/components/Bootstrap/DropdownList.js
+++ b/src/components/Bootstrap/DropdownList.js
@@ -38,7 +38,7 @@ type Props = {
   defaultIsOpen?: boolean,
 
   items: Array<Item>,
-  onItemPicked: (value: ItemValue) => void,
+  onItemPicked?: (value: ItemValue) => void,
   filter?: (searchTerm: string, item: Item) => boolean,
 };
 
@@ -89,7 +89,9 @@ export default class DropdownList extends React.Component<Props, State> {
                 onClick={(e) => {
                   e.preventDefault();
                   hideContent();
-                  props.onItemPicked(item.value);
+                  if (props.onItemPicked) {
+                    props.onItemPicked(item.value);
+                  }
                 }}>
                 <div className="text-left">
                   {String(item.label)}

--- a/src/components/FileSelectors.js
+++ b/src/components/FileSelectors.js
@@ -13,12 +13,15 @@ export type StateProps = {
   dataPaths: Array<string>,
   filename: ?string,
 
+  childrenIndexes: ?Array<number>,
+  selectedChildIndex: ?number,
   selectedChunkId: ?ChunkID,
   chunksByParent: Array<Child>,
 };
 
 export type DispatchProps = {
   onPickedFile: (path: string) => void,
+  onPickedChild: (childIndex: number) => void,
   onSelectChunkId: (chunkId: ChunkID) => void,
 };
 
@@ -33,15 +36,57 @@ export default function FileSelectors(props: Props) {
     return null;
   }
 
+  const childPicker = (props.childrenIndexes && props.childrenIndexes.length > 1)
+    ? (
+      <div className="form-group" onClick={willStopPropagation}>
+        <label
+          className="col-sm-1 control-label"
+          htmlFor="data-child-picker">
+          Child
+        </label>
+        <div className="col-sm-11">
+          <JsonFilePicker
+            id="data-child-picker"
+            dataPaths={(props.childrenIndexes || []).map(String)}
+            selected={String(props.selectedChildIndex)}
+            onChange={(event: SyntheticInputEvent<>) => {
+              if (event.target.value) {
+                props.onPickedChild(parseInt(event.target.value, 10));
+              }
+            }}
+          />
+        </div>
+      </div>
+    )
+    : null;
+
+  const chunkPicker = (props.selectedChildIndex !== null)
+    ? (
+      <div className="form-group" onClick={willStopPropagation}>
+        <label className="col-sm-1 control-label">Chunk</label>
+        <div className="col-sm-11">
+          <ChunkDropdown
+            chunksByParent={props.chunksByParent}
+            selectedChunkId={props.selectedChunkId}
+            onSelectChunkId={props.onSelectChunkId}
+          />
+        </div>
+      </div>
+    )
+    : null;
+
   return (
     <div className="row form-horizontal">
       <div className="col-sm-11">
         <div className="form-group">
-          <label className="col-sm-1 control-label">Filename</label>
+          <label
+            className="col-sm-1 control-label"
+            htmlFor="data-file-picker">
+            Filename
+          </label>
           <div className="col-sm-11" onClick={willStopPropagation}>
             <JsonFilePicker
               id="data-file-picker"
-              className="form-control"
               dataPaths={props.dataPaths}
               selected={props.filename}
               onChange={(event: SyntheticInputEvent<>) => {
@@ -52,16 +97,8 @@ export default function FileSelectors(props: Props) {
             />
           </div>
         </div>
-        <div className="form-group" onClick={willStopPropagation}>
-          <label className="col-sm-1 control-label">Chunk</label>
-          <div className="col-sm-11">
-            <ChunkDropdown
-              chunksByParent={props.chunksByParent}
-              selectedChunkId={props.selectedChunkId}
-              onSelectChunkId={props.onSelectChunkId}
-            />
-          </div>
-        </div>
+        {childPicker}
+        {chunkPicker}
       </div>
     </div>
   );

--- a/src/components/FileSelectorsContainer.js
+++ b/src/components/FileSelectorsContainer.js
@@ -9,14 +9,20 @@ import FileSelectors from './FileSelectors';
 import {connect} from 'react-redux';
 import {
   fetchDataFile,
+  PickedChild,
   PickedChunk,
 } from '../utils/actions';
 
 const mapStateToProps = (state: State): StateProps => {
+  const children = (state.jsonChildren && state.selectedFilename)
+    ? state.jsonChildren[state.selectedFilename]
+    : null;
+
   return {
     dataPaths: Object.keys(state.dataPaths),
     filename: state.selectedFilename,
-
+    childrenIndexes: children ? children.map((k, i) => i) : null,
+    selectedChildIndex: state.selectedChildIndex,
     selectedChunkId: state.selectedChunkId,
     chunksByParent: state.calculatedFullModuleData
       ? state.calculatedFullModuleData.chunksByParent
@@ -27,6 +33,7 @@ const mapStateToProps = (state: State): StateProps => {
 const mapDispatchToProps = (dispatch: Dispatch): DispatchProps => {
   return {
     onPickedFile: fetchDataFile(dispatch),
+    onPickedChild: PickedChild(dispatch),
     onSelectChunkId: PickedChunk(dispatch),
   };
 };

--- a/src/components/JsonFilePicker.js
+++ b/src/components/JsonFilePicker.js
@@ -8,7 +8,6 @@ type Props = {
   dataPaths: ?Array<string>,
   selected: ?string,
   id?: string,
-  className?: string,
   onChange: (event: SyntheticInputEvent<>) => void,
 };
 
@@ -25,7 +24,7 @@ export default function JsonFilePicker(props: Props) {
     <select
       id={props.id}
       value={props.selected || ''}
-      className={props.className}
+      className="form-control"
       onChange={props.onChange}>
       <option value=""></option>
       {props.dataPaths.map((file) =>

--- a/src/components/__stories__/FileSelectors.stories.js
+++ b/src/components/__stories__/FileSelectors.stories.js
@@ -12,10 +12,13 @@ storiesOf('FileSelectors', module)
     <FileSelectors
       dataPaths={[]}
       filename={null}
+      childrenIndexes={null}
+      selectedChildIndex={null}
       selectedChunkId={null}
       chunksByParent={[]}
       onChangedMode={action('on change mode')}
       onPickedFile={action('on stats file picked')}
+      onPickedChild={action('on child index picked')}
       onSelectChunkId={action('on select chunk id')}
     />
   ))
@@ -23,10 +26,13 @@ storiesOf('FileSelectors', module)
     <FileSelectors
       dataPaths={['stats.json']}
       filename={null}
+      childrenIndexes={null}
+      selectedChildIndex={null}
       selectedChunkId={null}
       chunksByParent={[]}
       onChangedMode={action('on change mode')}
       onPickedFile={action('on stats file picked')}
+      onPickedChild={action('on child index picked')}
       onSelectChunkId={action('on select chunk id')}
     />
   ))
@@ -34,10 +40,13 @@ storiesOf('FileSelectors', module)
     <FileSelectors
       dataPaths={['stats.json']}
       filename={'stats.json'}
+      childrenIndexes={[0]}
+      selectedChildIndex={null}
       selectedChunkId={null}
       chunksByParent={[]}
       onChangedMode={action('on change mode')}
       onPickedFile={action('on stats file picked')}
+      onPickedChild={action('on child index picked')}
       onSelectChunkId={action('on select chunk id')}
     />
   ))
@@ -45,10 +54,13 @@ storiesOf('FileSelectors', module)
     <FileSelectors
       dataPaths={[]}
       filename={'stats.json'}
+      childrenIndexes={[0]}
+      selectedChildIndex={null}
       selectedChunkId={null}
       chunksByParent={[]}
       onChangedMode={action('on change mode')}
       onPickedFile={action('on stats file picked')}
+      onPickedChild={action('on child index picked')}
       onSelectChunkId={action('on select chunk id')}
     />
   ));

--- a/src/components/__tests__/__snapshots__/Storyshots.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Storyshots.test.js.snap
@@ -3391,6 +3391,7 @@ exports[`Storyshots FileSelectors Filename picked 1`] = `
     >
       <label
         className="col-sm-1 control-label"
+        htmlFor="data-file-picker"
       >
         Filename
       </label>
@@ -3415,40 +3416,6 @@ exports[`Storyshots FileSelectors Filename picked 1`] = `
         </select>
       </div>
     </div>
-    <div
-      className="form-group"
-      onClick={[Function]}
-    >
-      <label
-        className="col-sm-1 control-label"
-      >
-        Chunk
-      </label>
-      <div
-        className="col-sm-11"
-      >
-        <div
-          className="btn-group"
-          style={undefined}
-        >
-          <button
-            aria-expanded={false}
-            aria-haspopup="true"
-            className="btn btn-default dropdown-toggle"
-            data-toggle="dropdown"
-            disabled="disabed"
-            onClick={null}
-            type="button"
-          >
-            - pick a chunk -
-             
-            <span
-              className="caret"
-            />
-          </button>
-        </div>
-      </div>
-    </div>
   </div>
 </div>
 `;
@@ -3469,6 +3436,7 @@ exports[`Storyshots FileSelectors No filename, items in list 1`] = `
     >
       <label
         className="col-sm-1 control-label"
+        htmlFor="data-file-picker"
       >
         Filename
       </label>
@@ -3491,40 +3459,6 @@ exports[`Storyshots FileSelectors No filename, items in list 1`] = `
             stats.json
           </option>
         </select>
-      </div>
-    </div>
-    <div
-      className="form-group"
-      onClick={[Function]}
-    >
-      <label
-        className="col-sm-1 control-label"
-      >
-        Chunk
-      </label>
-      <div
-        className="col-sm-11"
-      >
-        <div
-          className="btn-group"
-          style={undefined}
-        >
-          <button
-            aria-expanded={false}
-            aria-haspopup="true"
-            className="btn btn-default dropdown-toggle"
-            data-toggle="dropdown"
-            disabled="disabed"
-            onClick={null}
-            type="button"
-          >
-            - pick a chunk -
-             
-            <span
-              className="caret"
-            />
-          </button>
-        </div>
       </div>
     </div>
   </div>

--- a/src/components/stats/ChunkDropdown.js
+++ b/src/components/stats/ChunkDropdown.js
@@ -30,9 +30,6 @@ export default function ChunkDropdown(props: Props) {
     <DropdownList
       scrollable={true}
       disabled={chunkList.length === 0}
-      onItemPicked={(value: string | number) => {
-        props.onSelectChunkId(value);
-      }}
       items={chunkList.map((chunk) => ({
         node(hideContent) {
           return (
@@ -54,7 +51,7 @@ export default function ChunkDropdown(props: Props) {
             </Button>
           );
         },
-        value: chunk.name,
+        value: chunk.id,
       }))}>
       {label}
     </DropdownList>

--- a/src/stats/chunkSizes.js
+++ b/src/stats/chunkSizes.js
@@ -19,11 +19,9 @@ export type ChunkSize = {
 };
 
 export default function chunkSizes(
-  rawStats: {[filename: string]: RawStats},
+  rawStats: Array<RawStats>,
 ): Array<Array<ChunkSize>> {
-  return Object.keys(rawStats).map((filename) => {
-    const stats = rawStats[filename];
-
+  return rawStats.map((stats) => {
     const chunksByParent = getEntryHeirarchy(stats);
     const importedChunkNames = getChunkNamesFromImportedModules(stats);
 

--- a/src/types/__tests__/getRawStats.test.js
+++ b/src/types/__tests__/getRawStats.test.js
@@ -152,9 +152,9 @@ describe('getRawStats', () => {
       const stats = getRawStats('test-stats.json', json);
 
       isRawStats(stats['test-stats.json']);
-      expect(stats).toEqual({
-        'test-stats.json': json
-      });
+      expect(stats).toEqual([
+        json
+      ]);
       // eslint-disable-next-line no-console
       expect(console.error).not.toHaveBeenCalled();
     });
@@ -170,9 +170,9 @@ describe('getRawStats', () => {
       const stats = getRawStats('test-stats.json', json);
 
       isRawStats(stats['test-stats.json']);
-      expect(stats).toEqual({
-        'test-stats.json': json.children[0],
-      });
+      expect(stats).toEqual([
+        json.children[0],
+      ]);
       expectSingleConfigToFallThroughToMulti();
     });
 
@@ -190,10 +190,10 @@ describe('getRawStats', () => {
       const stats = getRawStats('test-stats.json', json);
 
       isRawStats(stats['test-stats.json']);
-      expect(stats).toEqual({
-        'test-stats.json (multi 0)': json.children[0],
-        'test-stats.json (multi 1)': json.children[1],
-      });
+      expect(stats).toEqual([
+        json.children[0],
+        json.children[1],
+      ]);
       expectSingleConfigToFallThroughToMulti();
     });
   });

--- a/src/types/getRawStats.js
+++ b/src/types/getRawStats.js
@@ -15,20 +15,14 @@ function invariant(condition: boolean, message: string): void {
 export default function getRawStats(
   filename: string,
   json: ParsedJSON,
-): {[filename: string]: RawStats} {
+): Array<RawStats> {
   try {
     const stats = getStatsJson(json);
-    return {
-      [filename]: stats,
-    };
+    return [stats];
   } catch (singleError) {
     try {
       const multiStats = getMultiStatsJson(json);
-      return multiStats.children.reduce((multi, json, index) => {
-        const suffix = multiStats.children.length > 1 ? ` (multi ${index})` : '';
-        multi[filename + suffix] = json;
-        return multi;
-      }, {});
+      return multiStats.children;
     } catch (multiError) {
       throw new Error('Unable to find required fields.');
     }

--- a/src/utils/__tests__/reducer.test.js
+++ b/src/utils/__tests__/reducer.test.js
@@ -150,20 +150,22 @@ describe('reducer', () => {
 
   describe('LoadedStatsAtPath action', () => {
     it('should clone the state when reduced', () => {
-      expect(LoadedStatsAtPath(mockDispatch)('test-file.json', {})).toCloneState();
+      expect(LoadedStatsAtPath(mockDispatch)('test-file.json', {chunks:[], modules: []})).toCloneState();
     });
 
     it('should ensure the filename is ready in dataPaths', () => {
       const state = {...INITIAL_STATE};
-      const action = LoadedStatsAtPath(mockDispatch)('test-file.json', {});
+      const action = LoadedStatsAtPath(mockDispatch)('test-file.json', {chunks:[], modules: []});
 
       const newState = reducer(state, action);
       expect(newState).toEqual(expect.objectContaining({
         dataPaths: {
           'test-file.json': 'ready',
         },
-        json: {
-          'test-file.json': expect.objectContaining({}),
+        jsonChildren: {
+          'test-file.json': expect.arrayContaining([
+            expect.objectContaining({chunks:[], modules: []}),
+          ]),
         },
       }));
     });


### PR DESCRIPTION
This resolves an issue where multi-config stats files were not parsed
properly if they were loaded from a pre-configured server endpoint.