### PR TITLE
Smattering of render optimizations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ script:
 
   - yarn rebuild:integration-fixtures
   - yarn react-scripts test --env=jsdom --coverage
-  - yarn test:all --coverage
   - yarn codecov
   - yarn build-storybook -o 'docs/storybook'
   - |

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "array-includes": "^3.0.3",
     "babel-cli": "^6.26.0",
     "bootstrap": "^3.3.7",
+    "console-shim": "^1.0.3",
     "flow-typed": "^2.1.2",
     "invariant": "^2.2.2",
     "load-pkg": "^3.0.1",

--- a/src/__test_helpers__/shims.js
+++ b/src/__test_helpers__/shims.js
@@ -5,6 +5,7 @@
 import values from 'object.values';
 import includes from 'array-includes';
 import 'raf/polyfill';
+import 'console-shim';
 
 if (!Object.values) {
   values.shim();

--- a/src/components/Bootstrap/Button.js
+++ b/src/components/Bootstrap/Button.js
@@ -44,7 +44,7 @@ export default function Button(props: ButtonProps) {
     colorToClass('btn', props.color, 'default'),
     displayToClass(props.display),
     sizeToClass(props.size),
-  ].filter(_ => _).join(' ');
+  ].join(' ');
 
   return (
     <button
@@ -71,7 +71,7 @@ export function Link(props: LinkProps) {
     'btn',
     colorToClass('btn', props.color, 'link'),
     sizeToClass(props.size),
-  ].filter(_ => _).join(' ');
+  ].join(' ');
 
   return (
     <a
@@ -96,7 +96,7 @@ export function DropdownToggleButton(props: DropdownToggleProps) {
     colorToClass('btn', props.color, 'default'),
     sizeToClass(props.size),
     'dropdown-toggle',
-  ].filter(_ => _).join(' ');
+  ].join(' ');
 
   return (
     <button

--- a/src/components/Bootstrap/Dropdown.js
+++ b/src/components/Bootstrap/Dropdown.js
@@ -103,11 +103,9 @@ export default class Dropdown extends React.Component<Props, State> {
           'btn-group',
           isOpenClass,
           sizeToClass(this.props.size),
-        ].filter(_ => _).join(' ')}
+        ].join(' ')}
         ref={(div) => {
-          if (div instanceof HTMLElement) {
-            this._dropDownMenu = div;
-          }
+          this._dropDownMenu = div;
         }}
         style={this.props.style}>
         {this.props.split
@@ -182,7 +180,7 @@ export default class Dropdown extends React.Component<Props, State> {
     const classNames = [
       'dropdown-menu',
       this.props.align === 'right' ? 'dropdown-menu-right' : '',
-    ].filter(_ => _).join(' ');
+    ].join(' ');
 
     const content = this.props.getContent(this.onHide);
     if (Array.isArray(content)) {
@@ -191,9 +189,7 @@ export default class Dropdown extends React.Component<Props, State> {
           className={classNames}
           {...this.getScrollableProps()}
           ref={(ul) => {
-            if (ul instanceof HTMLElement) {
-              this._flyout = ul;
-            }
+            this._flyout = ul;
           }}>
           {content}
         </ul>
@@ -204,9 +200,7 @@ export default class Dropdown extends React.Component<Props, State> {
           className={classNames}
           {...this.getScrollableProps()}
           ref={(div) => {
-            if (div instanceof HTMLElement) {
-              this._flyout = div;
-            }
+            this._flyout = div;
           }}>
           {content}
         </div>

--- a/src/components/Bootstrap/Dropdown.js
+++ b/src/components/Bootstrap/Dropdown.js
@@ -67,13 +67,23 @@ export default class Dropdown extends React.Component<Props, State> {
   }
 
   componentDidMount() {
-    document.addEventListener('click', this.onDocumentClick);
+    if (this.state.isOpen) {
+      document.addEventListener('click', this.onDocumentClick);
 
-    if (this.state.waitForDropdownMenu) {
-      // force a re-render during mount to properly measure _dropDownMenu
-      this.setState({
-        waitForDropdownMenu: false,
-      });
+      if (this.state.waitForDropdownMenu) {
+        // force a re-render during mount to properly measure _dropDownMenu
+        this.setState({
+          waitForDropdownMenu: false,
+        });
+      }
+    }
+  }
+
+  componentDidUpdate(prevProps: Props, prevState: State) {
+    if (this.state.isOpen && !prevState.isOpen) {
+      document.addEventListener('click', this.onDocumentClick);
+    } else if (!this.state.isOpen) {
+      document.removeEventListener('click', this.onDocumentClick);
     }
   }
 

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -4,6 +4,8 @@
 
 import * as React from 'react';
 
+import {getClassName} from './Bootstrap/GlyphiconNames';
+
 export default function Navbar() {
   return (
     <nav className="navbar navbar-default navbar-fixed-top navbar-inverse">
@@ -17,12 +19,18 @@ export default function Navbar() {
             Bonsai
           </a>
           <p className="navbar-text">
+            <span
+              className={getClassName('tree-conifer')}
+              aria-hidden="true"></span>
             Trim your dependency trees
           </p>
         </div>
         <ul className="nav navbar-nav navbar-right">
           <li>
             <a className="navbar-link" href="https://pinterest.github.io/bonsai/">
+              <span
+                className={getClassName('book')}
+                aria-hidden="true"></span>&nbsp;
               Docs
             </a>
           </li>

--- a/src/components/OffsetPageAnchor.js
+++ b/src/components/OffsetPageAnchor.js
@@ -14,7 +14,7 @@ export default function OffsetPageAnchor(
 ) {
   return {
     ...props,
-    className: ['OffsetPageSection', props.className].filter(_ => _).join(' '),
+    className: ['OffsetPageSection', props.className].join(' '),
     tabIndex: -1,
     id: anchor,
   };

--- a/src/components/Unit.js
+++ b/src/components/Unit.js
@@ -8,6 +8,8 @@ const NBSP = '\u00A0';
 
 type Props = {
   bytes: number,
+  className?: string,
+  elem?: 'span' | 'td',
 };
 
 function formatBytes(bytes) {
@@ -32,10 +34,10 @@ function toInt(n: number) {
 }
 
 export default function Unit(props: Props) {
+  const Elem = props.elem || 'span';
   return (
-    <span title={toInt(props.bytes) + ' bytes'}>
+    <Elem className={props.className} title={toInt(props.bytes) + ' bytes'}>
       {formatBytes(props.bytes)}
-    </span>
+    </Elem>
   );
 }
-

--- a/src/components/__stories__/Unit.stories.js
+++ b/src/components/__stories__/Unit.stories.js
@@ -7,7 +7,7 @@ import { storiesOf } from '@storybook/react';
 
 import Unit from '../Unit';
 
-storiesOf('Unit', module)
+storiesOf('Unit/sizes', module)
   .add('0 Bytes (b)', () => (
     <Unit bytes={0} />
   ))
@@ -25,4 +25,15 @@ storiesOf('Unit', module)
   ))
   .add('2.4 Terabytes (TB)', () => (
     <Unit bytes={2400000000000} />
+  ));
+storiesOf('Unit/html', module)
+  .add('with className', () => (
+    <Unit bytes={2400} className="pull-right" />
+  ))
+  .add('with elem=table-cell', () => (
+    <table className="table table-bordered">
+      <tbody>
+        <tr><Unit elem='td' bytes={2400} /></tr>
+      </tbody>
+    </table>
   ));

--- a/src/components/__tests__/OffsetPageAnchor.test.js
+++ b/src/components/__tests__/OffsetPageAnchor.test.js
@@ -7,7 +7,7 @@ import OffsetPageAnchor from '../OffsetPageAnchor';
 describe('OffsetPageAnchor', () => {
   it('should return an object with the anchor set', () => {
     expect(OffsetPageAnchor('foobar')).toEqual({
-      className: 'OffsetPageSection',
+      className: 'OffsetPageSection ',
       tabIndex: -1,
       id: 'foobar',
     });
@@ -30,7 +30,7 @@ describe('OffsetPageAnchor', () => {
     };
     expect(OffsetPageAnchor('foobar', props)).toEqual({
       title: 'Click for Foo Bar',
-      className: 'OffsetPageSection',
+      className: 'OffsetPageSection ',
       tabIndex: -1,
       id: 'foobar',
     });

--- a/src/components/__tests__/__snapshots__/Storyshots.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Storyshots.test.js.snap
@@ -23,6 +23,10 @@ exports[`Storyshots App Done loading 1`] = `
         <p
           className="navbar-text"
         >
+          <span
+            aria-hidden="true"
+            className="glyphicon glyphicon-tree-conifer"
+          />
           Trim your dependency trees
         </p>
       </div>
@@ -34,7 +38,11 @@ exports[`Storyshots App Done loading 1`] = `
             className="navbar-link"
             href="https://pinterest.github.io/bonsai/"
           >
-            Docs
+            <span
+              aria-hidden="true"
+              className="glyphicon glyphicon-book"
+            />
+              Docs
           </a>
         </li>
         <li>
@@ -142,6 +150,10 @@ exports[`Storyshots App Loading up a file 1`] = `
         <p
           className="navbar-text"
         >
+          <span
+            aria-hidden="true"
+            className="glyphicon glyphicon-tree-conifer"
+          />
           Trim your dependency trees
         </p>
       </div>
@@ -153,7 +165,11 @@ exports[`Storyshots App Loading up a file 1`] = `
             className="navbar-link"
             href="https://pinterest.github.io/bonsai/"
           >
-            Docs
+            <span
+              aria-hidden="true"
+              className="glyphicon glyphicon-book"
+            />
+              Docs
           </a>
         </li>
         <li>
@@ -236,6 +252,10 @@ exports[`Storyshots App No filename, empty list 1`] = `
         <p
           className="navbar-text"
         >
+          <span
+            aria-hidden="true"
+            className="glyphicon glyphicon-tree-conifer"
+          />
           Trim your dependency trees
         </p>
       </div>
@@ -247,7 +267,11 @@ exports[`Storyshots App No filename, empty list 1`] = `
             className="navbar-link"
             href="https://pinterest.github.io/bonsai/"
           >
-            Docs
+            <span
+              aria-hidden="true"
+              className="glyphicon glyphicon-book"
+            />
+              Docs
           </a>
         </li>
         <li>
@@ -371,7 +395,7 @@ exports[`Storyshots BlacklistTable Module with no children removed 1`] = `
     </thead>
     <tbody>
       <tr
-        className="OffsetPageSection"
+        className="OffsetPageSection "
         id="300"
         tabIndex={-1}
       >
@@ -385,24 +409,21 @@ exports[`Storyshots BlacklistTable Module with no children removed 1`] = `
         </td>
         <td
           className="vert-align numeric"
+          title="300 bytes"
         >
-          <span
-            title="300 bytes"
-          >
-            300 B
-          </span>
+          300 B
         </td>
         <td
           className="vert-align numeric"
         >
           <div
-            className="btn-group"
+            className="btn-group  "
             style={undefined}
           >
             <button
               aria-expanded={false}
               aria-haspopup="true"
-              className="btn btn-link dropdown-toggle"
+              className="btn btn-link  dropdown-toggle"
               data-toggle="dropdown"
               disabled="disabed"
               onClick={null}
@@ -420,13 +441,13 @@ exports[`Storyshots BlacklistTable Module with no children removed 1`] = `
           className="vert-align numeric"
         >
           <div
-            className="btn-group"
+            className="btn-group  "
             style={undefined}
           >
             <button
               aria-expanded={false}
               aria-haspopup="true"
-              className="btn btn-link dropdown-toggle"
+              className="btn btn-link  dropdown-toggle"
               data-toggle="dropdown"
               disabled="disabed"
               onClick={null}
@@ -444,7 +465,7 @@ exports[`Storyshots BlacklistTable Module with no children removed 1`] = `
           className="vert-align"
         >
           <button
-            className="btn btn-danger"
+            className="btn btn-danger  "
             disabled={null}
             onClick={[Function]}
             style={null}
@@ -481,12 +502,9 @@ exports[`Storyshots BlacklistTable Module with no children removed 1`] = `
         </th>
         <td
           className="numeric"
+          title="300 bytes"
         >
-          <span
-            title="300 bytes"
-          >
-            300 B
-          </span>
+          300 B
         </td>
         <td
           colSpan="3"
@@ -537,7 +555,7 @@ exports[`Storyshots BlacklistTable Module with some children removed 1`] = `
     </thead>
     <tbody>
       <tr
-        className="OffsetPageSection"
+        className="OffsetPageSection "
         id="1"
         tabIndex={-1}
       >
@@ -551,24 +569,21 @@ exports[`Storyshots BlacklistTable Module with some children removed 1`] = `
         </td>
         <td
           className="vert-align numeric"
+          title="100 bytes"
         >
-          <span
-            title="100 bytes"
-          >
-            100 B
-          </span>
+          100 B
         </td>
         <td
           className="vert-align numeric"
         >
           <div
-            className="btn-group"
+            className="btn-group  "
             style={undefined}
           >
             <button
               aria-expanded={false}
               aria-haspopup="true"
-              className="btn btn-link dropdown-toggle"
+              className="btn btn-link  dropdown-toggle"
               data-toggle="dropdown"
               disabled="disabed"
               onClick={null}
@@ -586,13 +601,13 @@ exports[`Storyshots BlacklistTable Module with some children removed 1`] = `
           className="vert-align numeric"
         >
           <div
-            className="btn-group"
+            className="btn-group  "
             style={undefined}
           >
             <button
               aria-expanded={false}
               aria-haspopup="true"
-              className="btn btn-link dropdown-toggle"
+              className="btn btn-link  dropdown-toggle"
               data-toggle="dropdown"
               disabled="disabed"
               onClick={null}
@@ -610,7 +625,7 @@ exports[`Storyshots BlacklistTable Module with some children removed 1`] = `
           className="vert-align"
         >
           <button
-            className="btn btn-danger"
+            className="btn btn-danger  "
             disabled={null}
             onClick={[Function]}
             style={null}
@@ -627,7 +642,7 @@ exports[`Storyshots BlacklistTable Module with some children removed 1`] = `
           colSpan="6"
         >
           <button
-            className="btn btn-default btn-xs"
+            className="btn btn-default  btn-xs"
             disabled={null}
             onClick={[Function]}
             style={null}
@@ -670,12 +685,9 @@ exports[`Storyshots BlacklistTable Module with some children removed 1`] = `
         </th>
         <td
           className="numeric"
+          title="1,000 bytes"
         >
-          <span
-            title="1,000 bytes"
-          >
-            1 KB
-          </span>
+          1 KB
         </td>
         <td
           colSpan="3"
@@ -688,7 +700,7 @@ exports[`Storyshots BlacklistTable Module with some children removed 1`] = `
 
 exports[`Storyshots Bootstrap/Button Block 1`] = `
 <button
-  className="btn btn-default btn-block"
+  className="btn btn-default btn-block "
   disabled={null}
   onClick={[Function]}
   style={null}
@@ -700,7 +712,7 @@ exports[`Storyshots Bootstrap/Button Block 1`] = `
 
 exports[`Storyshots Bootstrap/Button Disabled 1`] = `
 <button
-  className="btn btn-default"
+  className="btn btn-default  "
   disabled="disabed"
   onClick={null}
   style={null}
@@ -712,7 +724,7 @@ exports[`Storyshots Bootstrap/Button Disabled 1`] = `
 
 exports[`Storyshots Bootstrap/Button Disabled Success 1`] = `
 <button
-  className="btn btn-success"
+  className="btn btn-success  "
   disabled="disabed"
   onClick={null}
   style={null}
@@ -724,7 +736,7 @@ exports[`Storyshots Bootstrap/Button Disabled Success 1`] = `
 
 exports[`Storyshots Bootstrap/Button Large 1`] = `
 <button
-  className="btn btn-default btn-lg"
+  className="btn btn-default  btn-lg"
   disabled={null}
   onClick={[Function]}
   style={null}
@@ -736,7 +748,7 @@ exports[`Storyshots Bootstrap/Button Large 1`] = `
 
 exports[`Storyshots Bootstrap/Button Success 1`] = `
 <button
-  className="btn btn-success"
+  className="btn btn-success  "
   disabled={null}
   onClick={[Function]}
   style={null}
@@ -748,7 +760,7 @@ exports[`Storyshots Bootstrap/Button Success 1`] = `
 
 exports[`Storyshots Bootstrap/Button With onClick 1`] = `
 <button
-  className="btn btn-default"
+  className="btn btn-default  "
   disabled={null}
   onClick={[Function]}
   style={null}
@@ -812,13 +824,13 @@ exports[`Storyshots Bootstrap/CloseButton With onClick 1`] = `
 
 exports[`Storyshots Bootstrap/Dropdown Basic 1`] = `
 <div
-  className="btn-group"
+  className="btn-group  "
   style={undefined}
 >
   <button
     aria-expanded={false}
     aria-haspopup="true"
-    className="btn btn-default dropdown-toggle"
+    className="btn btn-default  dropdown-toggle"
     data-toggle="dropdown"
     disabled={null}
     onClick={[Function]}
@@ -835,13 +847,13 @@ exports[`Storyshots Bootstrap/Dropdown Basic 1`] = `
 
 exports[`Storyshots Bootstrap/Dropdown Basic Warning 1`] = `
 <div
-  className="btn-group"
+  className="btn-group  "
   style={undefined}
 >
   <button
     aria-expanded={false}
     aria-haspopup="true"
-    className="btn btn-warning dropdown-toggle"
+    className="btn btn-warning  dropdown-toggle"
     data-toggle="dropdown"
     disabled={null}
     onClick={[Function]}
@@ -858,13 +870,13 @@ exports[`Storyshots Bootstrap/Dropdown Basic Warning 1`] = `
 
 exports[`Storyshots Bootstrap/Dropdown Basic align right 1`] = `
 <div
-  className="btn-group"
+  className="btn-group  "
   style={undefined}
 >
   <button
     aria-expanded={false}
     aria-haspopup="true"
-    className="btn btn-default dropdown-toggle"
+    className="btn btn-default  dropdown-toggle"
     data-toggle="dropdown"
     disabled={null}
     onClick={[Function]}
@@ -881,7 +893,7 @@ exports[`Storyshots Bootstrap/Dropdown Basic align right 1`] = `
 
 exports[`Storyshots Bootstrap/Dropdown Basic custom style 1`] = `
 <div
-  className="btn-group"
+  className="btn-group  "
   style={
     Object {
       "background": "red",
@@ -892,7 +904,7 @@ exports[`Storyshots Bootstrap/Dropdown Basic custom style 1`] = `
   <button
     aria-expanded={false}
     aria-haspopup="true"
-    className="btn btn-default dropdown-toggle"
+    className="btn btn-default  dropdown-toggle"
     data-toggle="dropdown"
     disabled={null}
     onClick={[Function]}
@@ -909,13 +921,13 @@ exports[`Storyshots Bootstrap/Dropdown Basic custom style 1`] = `
 
 exports[`Storyshots Bootstrap/Dropdown Basic disabled 1`] = `
 <div
-  className="btn-group"
+  className="btn-group  "
   style={undefined}
 >
   <button
     aria-expanded={false}
     aria-haspopup="true"
-    className="btn btn-default dropdown-toggle"
+    className="btn btn-default  dropdown-toggle"
     data-toggle="dropdown"
     disabled="disabed"
     onClick={null}
@@ -932,13 +944,13 @@ exports[`Storyshots Bootstrap/Dropdown Basic disabled 1`] = `
 
 exports[`Storyshots Bootstrap/Dropdown Basic isOpen 1`] = `
 <div
-  className="btn-group open"
+  className="btn-group open "
   style={undefined}
 >
   <button
     aria-expanded={true}
     aria-haspopup="true"
-    className="btn btn-default dropdown-toggle"
+    className="btn btn-default  dropdown-toggle"
     data-toggle="dropdown"
     disabled={null}
     onClick={[Function]}
@@ -951,13 +963,13 @@ exports[`Storyshots Bootstrap/Dropdown Basic isOpen 1`] = `
     />
   </button>
   <div
-    className="dropdown-menu"
+    className="dropdown-menu "
   >
     <div
       className="col-sm-12"
     >
       <button
-        className="btn btn-success"
+        className="btn btn-success  "
         disabled={null}
         onClick={[Function]}
         style={null}
@@ -972,13 +984,13 @@ exports[`Storyshots Bootstrap/Dropdown Basic isOpen 1`] = `
 
 exports[`Storyshots Bootstrap/Dropdown List Content 1`] = `
 <div
-  className="btn-group"
+  className="btn-group  "
   style={undefined}
 >
   <button
     aria-expanded={false}
     aria-haspopup="true"
-    className="btn btn-default dropdown-toggle"
+    className="btn btn-default  dropdown-toggle"
     data-toggle="dropdown"
     disabled={null}
     onClick={[Function]}
@@ -995,13 +1007,13 @@ exports[`Storyshots Bootstrap/Dropdown List Content 1`] = `
 
 exports[`Storyshots Bootstrap/Dropdown List Content isOpen 1`] = `
 <div
-  className="btn-group open"
+  className="btn-group open "
   style={undefined}
 >
   <button
     aria-expanded={true}
     aria-haspopup="true"
-    className="btn btn-default dropdown-toggle"
+    className="btn btn-default  dropdown-toggle"
     data-toggle="dropdown"
     disabled={null}
     onClick={[Function]}
@@ -1014,7 +1026,7 @@ exports[`Storyshots Bootstrap/Dropdown List Content isOpen 1`] = `
     />
   </button>
   <ul
-    className="dropdown-menu"
+    className="dropdown-menu "
   >
     <li>
       <a
@@ -1067,13 +1079,13 @@ exports[`Storyshots Bootstrap/Dropdown List Content isOpen 1`] = `
 
 exports[`Storyshots Bootstrap/Dropdown List with long content 1`] = `
 <div
-  className="btn-group open"
+  className="btn-group open "
   style={undefined}
 >
   <button
     aria-expanded={true}
     aria-haspopup="true"
-    className="btn btn-default dropdown-toggle"
+    className="btn btn-default  dropdown-toggle"
     data-toggle="dropdown"
     disabled={null}
     onClick={[Function]}
@@ -1086,7 +1098,7 @@ exports[`Storyshots Bootstrap/Dropdown List with long content 1`] = `
     />
   </button>
   <ul
-    className="dropdown-menu"
+    className="dropdown-menu "
   >
     <li>
       <a
@@ -1547,13 +1559,13 @@ exports[`Storyshots Bootstrap/Dropdown List with long content on long page 1`] =
     </li>
   </ul>
   <div
-    className="btn-group open"
+    className="btn-group open "
     style={undefined}
   >
     <button
       aria-expanded={true}
       aria-haspopup="true"
-      className="btn btn-default dropdown-toggle"
+      className="btn btn-default  dropdown-toggle"
       data-toggle="dropdown"
       disabled={null}
       onClick={[Function]}
@@ -1566,7 +1578,7 @@ exports[`Storyshots Bootstrap/Dropdown List with long content on long page 1`] =
       />
     </button>
     <ul
-      className="dropdown-menu"
+      className="dropdown-menu "
     >
       <li>
         <a
@@ -2477,11 +2489,11 @@ exports[`Storyshots Bootstrap/Dropdown List with long content on long page 1`] =
 
 exports[`Storyshots Bootstrap/Dropdown Split Button 1`] = `
 <div
-  className="btn-group"
+  className="btn-group  "
   style={undefined}
 >
   <button
-    className="btn btn-default"
+    className="btn btn-default  "
     disabled={null}
     onClick={[Function]}
     style={null}
@@ -2492,7 +2504,7 @@ exports[`Storyshots Bootstrap/Dropdown Split Button 1`] = `
   <button
     aria-expanded={false}
     aria-haspopup="true"
-    className="btn btn-default dropdown-toggle"
+    className="btn btn-default  dropdown-toggle"
     data-toggle="dropdown"
     disabled={null}
     onClick={[Function]}
@@ -2513,11 +2525,11 @@ exports[`Storyshots Bootstrap/Dropdown Split Button 1`] = `
 
 exports[`Storyshots Bootstrap/Dropdown Split Button w/ Color 1`] = `
 <div
-  className="btn-group"
+  className="btn-group  "
   style={undefined}
 >
   <button
-    className="btn btn-success"
+    className="btn btn-success  "
     disabled={null}
     onClick={[Function]}
     style={null}
@@ -2528,7 +2540,7 @@ exports[`Storyshots Bootstrap/Dropdown Split Button w/ Color 1`] = `
   <button
     aria-expanded={false}
     aria-haspopup="true"
-    className="btn btn-success dropdown-toggle"
+    className="btn btn-success  dropdown-toggle"
     data-toggle="dropdown"
     disabled={null}
     onClick={[Function]}
@@ -2549,11 +2561,11 @@ exports[`Storyshots Bootstrap/Dropdown Split Button w/ Color 1`] = `
 
 exports[`Storyshots Bootstrap/Dropdown Split Button w/ Glyph 1`] = `
 <div
-  className="btn-group"
+  className="btn-group  "
   style={undefined}
 >
   <button
-    className="btn btn-default"
+    className="btn btn-default  "
     disabled={null}
     onClick={[Function]}
     style={null}
@@ -2564,7 +2576,7 @@ exports[`Storyshots Bootstrap/Dropdown Split Button w/ Glyph 1`] = `
   <button
     aria-expanded={false}
     aria-haspopup="true"
-    className="btn btn-default dropdown-toggle"
+    className="btn btn-default  dropdown-toggle"
     data-toggle="dropdown"
     disabled={null}
     onClick={[Function]}
@@ -2585,11 +2597,11 @@ exports[`Storyshots Bootstrap/Dropdown Split Button w/ Glyph 1`] = `
 
 exports[`Storyshots Bootstrap/Dropdown Split Button w/ List Content 1`] = `
 <div
-  className="btn-group"
+  className="btn-group  "
   style={undefined}
 >
   <button
-    className="btn btn-default"
+    className="btn btn-default  "
     disabled={null}
     onClick={[Function]}
     style={null}
@@ -2600,7 +2612,7 @@ exports[`Storyshots Bootstrap/Dropdown Split Button w/ List Content 1`] = `
   <button
     aria-expanded={false}
     aria-haspopup="true"
-    className="btn btn-default dropdown-toggle"
+    className="btn btn-default  dropdown-toggle"
     data-toggle="dropdown"
     disabled={null}
     onClick={[Function]}
@@ -2621,13 +2633,13 @@ exports[`Storyshots Bootstrap/Dropdown Split Button w/ List Content 1`] = `
 
 exports[`Storyshots Bootstrap/DropdownList Basic 1`] = `
 <div
-  className="btn-group"
+  className="btn-group  "
   style={undefined}
 >
   <button
     aria-expanded={false}
     aria-haspopup="true"
-    className="btn btn-default dropdown-toggle"
+    className="btn btn-default  dropdown-toggle"
     data-toggle="dropdown"
     disabled={null}
     onClick={[Function]}
@@ -2644,13 +2656,13 @@ exports[`Storyshots Bootstrap/DropdownList Basic 1`] = `
 
 exports[`Storyshots Bootstrap/DropdownList Custom filter 1`] = `
 <div
-  className="btn-group"
+  className="btn-group  "
   style={undefined}
 >
   <button
     aria-expanded={false}
     aria-haspopup="true"
-    className="btn btn-default dropdown-toggle"
+    className="btn btn-default  dropdown-toggle"
     data-toggle="dropdown"
     disabled={null}
     onClick={[Function]}
@@ -2667,13 +2679,13 @@ exports[`Storyshots Bootstrap/DropdownList Custom filter 1`] = `
 
 exports[`Storyshots Bootstrap/DropdownList Custom items 1`] = `
 <div
-  className="btn-group open"
+  className="btn-group open "
   style={undefined}
 >
   <button
     aria-expanded={true}
     aria-haspopup="true"
-    className="btn btn-default dropdown-toggle"
+    className="btn btn-default  dropdown-toggle"
     data-toggle="dropdown"
     disabled={null}
     onClick={[Function]}
@@ -2686,11 +2698,11 @@ exports[`Storyshots Bootstrap/DropdownList Custom items 1`] = `
     />
   </button>
   <ul
-    className="dropdown-menu"
+    className="dropdown-menu "
   >
     <li>
       <button
-        className="btn btn-default btn-block"
+        className="btn btn-default btn-block "
         disabled={null}
         onClick={[Function]}
         style={null}
@@ -2701,7 +2713,7 @@ exports[`Storyshots Bootstrap/DropdownList Custom items 1`] = `
     </li>
     <li>
       <button
-        className="btn btn-default btn-block"
+        className="btn btn-default btn-block "
         disabled={null}
         onClick={[Function]}
         style={null}
@@ -2712,7 +2724,7 @@ exports[`Storyshots Bootstrap/DropdownList Custom items 1`] = `
     </li>
     <li>
       <button
-        className="btn btn-default btn-block"
+        className="btn btn-default btn-block "
         disabled={null}
         onClick={[Function]}
         style={null}
@@ -2723,7 +2735,7 @@ exports[`Storyshots Bootstrap/DropdownList Custom items 1`] = `
     </li>
     <li>
       <button
-        className="btn btn-default btn-block"
+        className="btn btn-default btn-block "
         disabled={null}
         onClick={[Function]}
         style={null}
@@ -2734,7 +2746,7 @@ exports[`Storyshots Bootstrap/DropdownList Custom items 1`] = `
     </li>
     <li>
       <button
-        className="btn btn-default btn-block"
+        className="btn btn-default btn-block "
         disabled={null}
         onClick={[Function]}
         style={null}
@@ -2745,7 +2757,7 @@ exports[`Storyshots Bootstrap/DropdownList Custom items 1`] = `
     </li>
     <li>
       <button
-        className="btn btn-default btn-block"
+        className="btn btn-default btn-block "
         disabled={null}
         onClick={[Function]}
         style={null}
@@ -2756,7 +2768,7 @@ exports[`Storyshots Bootstrap/DropdownList Custom items 1`] = `
     </li>
     <li>
       <button
-        className="btn btn-default btn-block"
+        className="btn btn-default btn-block "
         disabled={null}
         onClick={[Function]}
         style={null}
@@ -2771,13 +2783,13 @@ exports[`Storyshots Bootstrap/DropdownList Custom items 1`] = `
 
 exports[`Storyshots Bootstrap/DropdownList Default filter 1`] = `
 <div
-  className="btn-group open"
+  className="btn-group open "
   style={undefined}
 >
   <button
     aria-expanded={true}
     aria-haspopup="true"
-    className="btn btn-default dropdown-toggle"
+    className="btn btn-default  dropdown-toggle"
     data-toggle="dropdown"
     disabled={null}
     onClick={[Function]}
@@ -2805,11 +2817,11 @@ exports[`Storyshots Bootstrap/DropdownList Default filter 1`] = `
     />
   </button>
   <ul
-    className="dropdown-menu"
+    className="dropdown-menu "
   >
     <li>
       <button
-        className="btn btn-link btn-block"
+        className="btn btn-link btn-block "
         disabled={null}
         onClick={[Function]}
         style={null}
@@ -2824,7 +2836,7 @@ exports[`Storyshots Bootstrap/DropdownList Default filter 1`] = `
     </li>
     <li>
       <button
-        className="btn btn-link btn-block"
+        className="btn btn-link btn-block "
         disabled={null}
         onClick={[Function]}
         style={null}
@@ -2839,7 +2851,7 @@ exports[`Storyshots Bootstrap/DropdownList Default filter 1`] = `
     </li>
     <li>
       <button
-        className="btn btn-link btn-block"
+        className="btn btn-link btn-block "
         disabled={null}
         onClick={[Function]}
         style={null}
@@ -2854,7 +2866,7 @@ exports[`Storyshots Bootstrap/DropdownList Default filter 1`] = `
     </li>
     <li>
       <button
-        className="btn btn-link btn-block"
+        className="btn btn-link btn-block "
         disabled={null}
         onClick={[Function]}
         style={null}
@@ -2869,7 +2881,7 @@ exports[`Storyshots Bootstrap/DropdownList Default filter 1`] = `
     </li>
     <li>
       <button
-        className="btn btn-link btn-block"
+        className="btn btn-link btn-block "
         disabled={null}
         onClick={[Function]}
         style={null}
@@ -2884,7 +2896,7 @@ exports[`Storyshots Bootstrap/DropdownList Default filter 1`] = `
     </li>
     <li>
       <button
-        className="btn btn-link btn-block"
+        className="btn btn-link btn-block "
         disabled={null}
         onClick={[Function]}
         style={null}
@@ -2899,7 +2911,7 @@ exports[`Storyshots Bootstrap/DropdownList Default filter 1`] = `
     </li>
     <li>
       <button
-        className="btn btn-link btn-block"
+        className="btn btn-link btn-block "
         disabled={null}
         onClick={[Function]}
         style={null}
@@ -2918,13 +2930,13 @@ exports[`Storyshots Bootstrap/DropdownList Default filter 1`] = `
 
 exports[`Storyshots Bootstrap/DropdownList Open is default 1`] = `
 <div
-  className="btn-group open"
+  className="btn-group open "
   style={undefined}
 >
   <button
     aria-expanded={true}
     aria-haspopup="true"
-    className="btn btn-default dropdown-toggle"
+    className="btn btn-default  dropdown-toggle"
     data-toggle="dropdown"
     disabled={null}
     onClick={[Function]}
@@ -2937,11 +2949,11 @@ exports[`Storyshots Bootstrap/DropdownList Open is default 1`] = `
     />
   </button>
   <ul
-    className="dropdown-menu"
+    className="dropdown-menu "
   >
     <li>
       <button
-        className="btn btn-link btn-block"
+        className="btn btn-link btn-block "
         disabled={null}
         onClick={[Function]}
         style={null}
@@ -2956,7 +2968,7 @@ exports[`Storyshots Bootstrap/DropdownList Open is default 1`] = `
     </li>
     <li>
       <button
-        className="btn btn-link btn-block"
+        className="btn btn-link btn-block "
         disabled={null}
         onClick={[Function]}
         style={null}
@@ -2971,7 +2983,7 @@ exports[`Storyshots Bootstrap/DropdownList Open is default 1`] = `
     </li>
     <li>
       <button
-        className="btn btn-link btn-block"
+        className="btn btn-link btn-block "
         disabled={null}
         onClick={[Function]}
         style={null}
@@ -2986,7 +2998,7 @@ exports[`Storyshots Bootstrap/DropdownList Open is default 1`] = `
     </li>
     <li>
       <button
-        className="btn btn-link btn-block"
+        className="btn btn-link btn-block "
         disabled={null}
         onClick={[Function]}
         style={null}
@@ -3001,7 +3013,7 @@ exports[`Storyshots Bootstrap/DropdownList Open is default 1`] = `
     </li>
     <li>
       <button
-        className="btn btn-link btn-block"
+        className="btn btn-link btn-block "
         disabled={null}
         onClick={[Function]}
         style={null}
@@ -3016,7 +3028,7 @@ exports[`Storyshots Bootstrap/DropdownList Open is default 1`] = `
     </li>
     <li>
       <button
-        className="btn btn-link btn-block"
+        className="btn btn-link btn-block "
         disabled={null}
         onClick={[Function]}
         style={null}
@@ -3031,7 +3043,7 @@ exports[`Storyshots Bootstrap/DropdownList Open is default 1`] = `
     </li>
     <li>
       <button
-        className="btn btn-link btn-block"
+        className="btn btn-link btn-block "
         disabled={null}
         onClick={[Function]}
         style={null}
@@ -3050,7 +3062,7 @@ exports[`Storyshots Bootstrap/DropdownList Open is default 1`] = `
 
 exports[`Storyshots Bootstrap/Link Disabled 1`] = `
 <a
-  className="btn btn-link"
+  className="btn btn-link "
   disabled="disabled"
   href="#"
   role="button"
@@ -3062,7 +3074,7 @@ exports[`Storyshots Bootstrap/Link Disabled 1`] = `
 
 exports[`Storyshots Bootstrap/Link Disabled Success 1`] = `
 <a
-  className="btn btn-success"
+  className="btn btn-success "
   disabled="disabled"
   href="#"
   role="button"
@@ -3086,7 +3098,7 @@ exports[`Storyshots Bootstrap/Link Large 1`] = `
 
 exports[`Storyshots Bootstrap/Link Opens new tab 1`] = `
 <a
-  className="btn btn-link"
+  className="btn btn-link "
   disabled={null}
   href="example.com"
   role="button"
@@ -3101,7 +3113,7 @@ exports[`Storyshots Bootstrap/Link Opens new tab 1`] = `
 
 exports[`Storyshots Bootstrap/Link Success 1`] = `
 <a
-  className="btn btn-success"
+  className="btn btn-success "
   disabled={null}
   href="javascript: alert('Linked!');"
   role="button"
@@ -3113,7 +3125,7 @@ exports[`Storyshots Bootstrap/Link Success 1`] = `
 
 exports[`Storyshots Bootstrap/Link With href 1`] = `
 <a
-  className="btn btn-link"
+  className="btn btn-link "
   disabled={null}
   href="javascript: alert('Linked!');"
   role="button"
@@ -3485,7 +3497,7 @@ exports[`Storyshots ChunkBreadcrumb First module without a parent 1`] = `
 
 exports[`Storyshots ExternalModuleLink Default 1`] = `
 <a
-  className="btn btn-link"
+  className="btn btn-link "
   disabled={null}
   href="http://example.com/./app/analytics/modules/AnalyticsMetric/AnalyticsMetric.js"
   role="button"
@@ -3521,13 +3533,13 @@ exports[`Storyshots FileSelectors Filename picked 1`] = `
         onClick={[Function]}
       >
         <div
-          className="btn-group"
+          className="btn-group  "
           style={undefined}
         >
           <button
             aria-expanded={false}
             aria-haspopup="true"
-            className="btn btn-default dropdown-toggle"
+            className="btn btn-default  dropdown-toggle"
             data-toggle="dropdown"
             disabled={null}
             onClick={[Function]}
@@ -3571,13 +3583,13 @@ exports[`Storyshots FileSelectors No filename, items in list 1`] = `
         onClick={[Function]}
       >
         <div
-          className="btn-group"
+          className="btn-group  "
           style={undefined}
         >
           <button
             aria-expanded={false}
             aria-haspopup="true"
-            className="btn btn-default dropdown-toggle"
+            className="btn btn-default  dropdown-toggle"
             data-toggle="dropdown"
             disabled={null}
             onClick={[Function]}
@@ -3647,7 +3659,7 @@ exports[`Storyshots SortLabel This field is type \`order\` 1`] = `
 
 exports[`Storyshots ToggleExpandModeButton Collapse-all mode picked 1`] = `
 <div
-  className="btn-group btn-xs"
+  className="btn-group  btn-xs"
   style={undefined}
 >
   <button
@@ -3670,7 +3682,7 @@ exports[`Storyshots ToggleExpandModeButton Collapse-all mode picked 1`] = `
 
 exports[`Storyshots ToggleExpandModeButton Expand-all mode picked 1`] = `
 <div
-  className="btn-group btn-xs"
+  className="btn-group  btn-xs"
   style={undefined}
 >
   <button
@@ -3693,7 +3705,7 @@ exports[`Storyshots ToggleExpandModeButton Expand-all mode picked 1`] = `
 
 exports[`Storyshots ToggleExpandModeButton Manual mode picked 1`] = `
 <div
-  className="btn-group btn-xs"
+  className="btn-group  btn-xs"
   style={undefined}
 >
   <button
@@ -3742,6 +3754,7 @@ exports[`Storyshots Unit/html with elem=table-cell 1`] = `
 
 exports[`Storyshots Unit/sizes 0 Bytes (b) 1`] = `
 <span
+  className={undefined}
   title="0 bytes"
 >
   0 B
@@ -3750,6 +3763,7 @@ exports[`Storyshots Unit/sizes 0 Bytes (b) 1`] = `
 
 exports[`Storyshots Unit/sizes 2.4 Bytes (b) 1`] = `
 <span
+  className={undefined}
   title="2 bytes"
 >
   2.4 B
@@ -3758,6 +3772,7 @@ exports[`Storyshots Unit/sizes 2.4 Bytes (b) 1`] = `
 
 exports[`Storyshots Unit/sizes 2.4 Gigabytes (GB) 1`] = `
 <span
+  className={undefined}
   title="2,400,000,000 bytes"
 >
   2.4 GB
@@ -3766,6 +3781,7 @@ exports[`Storyshots Unit/sizes 2.4 Gigabytes (GB) 1`] = `
 
 exports[`Storyshots Unit/sizes 2.4 Kilobytes (KB) 1`] = `
 <span
+  className={undefined}
   title="2,400 bytes"
 >
   2.4 KB
@@ -3774,6 +3790,7 @@ exports[`Storyshots Unit/sizes 2.4 Kilobytes (KB) 1`] = `
 
 exports[`Storyshots Unit/sizes 2.4 Megabytes (MB) 1`] = `
 <span
+  className={undefined}
   title="2,400,000 bytes"
 >
   2.4 MB
@@ -3782,6 +3799,7 @@ exports[`Storyshots Unit/sizes 2.4 Megabytes (MB) 1`] = `
 
 exports[`Storyshots Unit/sizes 2.4 Terabytes (TB) 1`] = `
 <span
+  className={undefined}
   title="2,400,000,000,000 bytes"
 >
   2.4 TB

--- a/src/components/__tests__/__snapshots__/Storyshots.test.js.snap
+++ b/src/components/__tests__/__snapshots__/Storyshots.test.js.snap
@@ -3714,7 +3714,33 @@ exports[`Storyshots ToggleExpandModeButton Manual mode picked 1`] = `
 </div>
 `;
 
-exports[`Storyshots Unit 0 Bytes (b) 1`] = `
+exports[`Storyshots Unit/html with className 1`] = `
+<span
+  className="pull-right"
+  title="2,400 bytes"
+>
+  2.4 KB
+</span>
+`;
+
+exports[`Storyshots Unit/html with elem=table-cell 1`] = `
+<table
+  className="table table-bordered"
+>
+  <tbody>
+    <tr>
+      <td
+        className={undefined}
+        title="2,400 bytes"
+      >
+        2.4 KB
+      </td>
+    </tr>
+  </tbody>
+</table>
+`;
+
+exports[`Storyshots Unit/sizes 0 Bytes (b) 1`] = `
 <span
   title="0 bytes"
 >
@@ -3722,7 +3748,7 @@ exports[`Storyshots Unit 0 Bytes (b) 1`] = `
 </span>
 `;
 
-exports[`Storyshots Unit 2.4 Bytes (b) 1`] = `
+exports[`Storyshots Unit/sizes 2.4 Bytes (b) 1`] = `
 <span
   title="2 bytes"
 >
@@ -3730,7 +3756,7 @@ exports[`Storyshots Unit 2.4 Bytes (b) 1`] = `
 </span>
 `;
 
-exports[`Storyshots Unit 2.4 Gigabytes (GB) 1`] = `
+exports[`Storyshots Unit/sizes 2.4 Gigabytes (GB) 1`] = `
 <span
   title="2,400,000,000 bytes"
 >
@@ -3738,7 +3764,7 @@ exports[`Storyshots Unit 2.4 Gigabytes (GB) 1`] = `
 </span>
 `;
 
-exports[`Storyshots Unit 2.4 Kilobytes (KB) 1`] = `
+exports[`Storyshots Unit/sizes 2.4 Kilobytes (KB) 1`] = `
 <span
   title="2,400 bytes"
 >
@@ -3746,7 +3772,7 @@ exports[`Storyshots Unit 2.4 Kilobytes (KB) 1`] = `
 </span>
 `;
 
-exports[`Storyshots Unit 2.4 Megabytes (MB) 1`] = `
+exports[`Storyshots Unit/sizes 2.4 Megabytes (MB) 1`] = `
 <span
   title="2,400,000 bytes"
 >
@@ -3754,7 +3780,7 @@ exports[`Storyshots Unit 2.4 Megabytes (MB) 1`] = `
 </span>
 `;
 
-exports[`Storyshots Unit 2.4 Terabytes (TB) 1`] = `
+exports[`Storyshots Unit/sizes 2.4 Terabytes (TB) 1`] = `
 <span
   title="2,400,000,000,000 bytes"
 >

--- a/src/components/stats/BlacklistTable.js
+++ b/src/components/stats/BlacklistTable.js
@@ -78,9 +78,10 @@ export default function BlasklistTable(props: Props) {
                 <td className="vert-align">
                   {eModule.name}
                 </td>
-                <td className="vert-align numeric">
-                  <Unit bytes={eModule.size} />
-                </td>
+                <Unit
+                  elem='td'
+                  className="vert-align numeric"
+                  bytes={eModule.size} />
                 <td className="vert-align numeric">
                   <RequiredByPanelContainer eModule={eModule} />
                 </td>
@@ -109,7 +110,10 @@ export default function BlasklistTable(props: Props) {
           <tr>
             <th></th>
             <th className="numeric">Total Size</th>
-            <td className="numeric"><Unit bytes={sum} /></td>
+            <Unit
+              elem='td'
+              className='numeric'
+              bytes={sum} />
             <td colSpan="3"></td>
           </tr>
         </tfoot>

--- a/src/components/stats/BlacklistTableBody.js
+++ b/src/components/stats/BlacklistTableBody.js
@@ -39,9 +39,10 @@ export default class BlacklistTableBody extends Component<Props, State> {
               <td className="vert-align">
                 {eModule.name}
               </td>
-              <td className="vert-align numeric">
-                <Unit bytes={eModule.size} />
-              </td>
+              <Unit
+                elem='td'
+                className="vert-align numeric"
+                bytes={eModule.size} />
               <td colSpan="3"></td>
             </tr>
           )}

--- a/src/components/stats/ChunkDropdown.js
+++ b/src/components/stats/ChunkDropdown.js
@@ -46,7 +46,7 @@ export default function ChunkDropdown(props: Props) {
                 className={[
                   'text-left',
                   chunk.indent ? 'ChunkDropdownPrefix' : '',
-                ].filter(_ => _).join(' ')}>
+                ].join(' ')}>
                 {chunk.name} ({chunk.id})
               </div>
             </Button>

--- a/src/components/stats/ModuleTable.js
+++ b/src/components/stats/ModuleTable.js
@@ -20,6 +20,7 @@ import ModuleTableHead from './ModuleTableHead';
 import React, { Component } from 'react';
 import scrollToAndFocus from '../../utils/scrollToAndFocus';
 import sortModules from '../../stats/sortModules';
+import withTimings from '../../utils/withTimings';
 
 export type OwnProps = {
   extendedModules: Array<ExtendedModule>,
@@ -43,6 +44,22 @@ export type DispatchProps = {
 
 export type Props = OwnProps & StateProps & DispatchProps;
 
+function getRows(props: Props) {
+  const rows = collapseModulesToRows(
+    sortModules(
+      filterModules(
+        props.extendedModules,
+        props.filters,
+      ),
+      props.sort,
+    ),
+  );
+  rows.forEach((row) => {
+    row.records = sortModules(row.records, props.sort);
+  });
+  return rows;
+}
+
 export default class ModuleTable extends Component<Props> {
   componentDidUpdate() {
     if (this.props.focusedRowID) {
@@ -52,19 +69,7 @@ export default class ModuleTable extends Component<Props> {
 
   render() {
     const props = this.props;
-
-    const rows = collapseModulesToRows(
-      sortModules(
-        filterModules(
-          props.extendedModules,
-          props.filters,
-        ),
-        props.sort,
-      ),
-    );
-    rows.forEach((row) => {
-      row.records = sortModules(row.records, props.sort);
-    });
+    const rows = withTimings('ModuleTable', 'getRows')(getRows, props);
 
     return (
       <table className="table table-hover" cellPadding="0" cellSpacing="0">

--- a/src/components/stats/ModuleTableBody.css
+++ b/src/components/stats/ModuleTableBody.css
@@ -10,3 +10,7 @@
 .ModuleTableBody-expanded-border {
   border-left-color: #337ab7;
 }
+
+.ModuleTableBody-main-cell {
+  width:100%;
+}

--- a/src/components/stats/ModuleTableBody.js
+++ b/src/components/stats/ModuleTableBody.js
@@ -131,12 +131,14 @@ function ModuleTableRow(props: TRProps) {
         ].filter(_ => _).join(' ')
       })}
     >
-      <td className="vert-align">
-        <ExternalModuleLink
-          prefix={process.env.REACT_APP_EXTERNAL_URL_PREFIX}
-          module={eModule}
-        />
-      </td>
+      {process.env.REACT_APP_EXTERNAL_URL_PREFIX
+        ? <td className="vert-align">
+          <ExternalModuleLink
+            prefix={process.env.REACT_APP_EXTERNAL_URL_PREFIX}
+            module={eModule}
+          />
+        </td>
+        : null}
       <td className="vert-align">
         {uniqueImports}
         {formatModuleName(eModule.name)}

--- a/src/components/stats/ModuleTableBody.js
+++ b/src/components/stats/ModuleTableBody.js
@@ -139,7 +139,7 @@ function ModuleTableRow(props: TRProps) {
           />
         </td>
         : null}
-      <td className="vert-align">
+      <td className="vert-align ModuleTableBody-main-cell">
         {uniqueImports}
         {formatModuleName(eModule.name)}
       </td>

--- a/src/components/stats/ModuleTableBody.js
+++ b/src/components/stats/ModuleTableBody.js
@@ -128,7 +128,7 @@ function ModuleTableRow(props: TRProps) {
           props.expanded && props.records.length > 1
             ? 'ModuleTableBody-expanded-border'
             : null,
-        ].filter(_ => _).join(' ')
+        ].join(' ')
       })}
     >
       {process.env.REACT_APP_EXTERNAL_URL_PREFIX

--- a/src/components/stats/ModuleTableBody.js
+++ b/src/components/stats/ModuleTableBody.js
@@ -103,11 +103,9 @@ function ModuleTableRow(props: TRProps) {
   const eModule = props.eModule;
   const records = props.records;
 
-  const moduleSize = props.expanded
-    ? <Unit bytes={eModule.size} />
-    : <Unit
-      bytes={records.reduce((sum, eModule) => sum + eModule.size, 0)}
-    />;
+  const moduleSizeBytes = props.expanded
+    ? eModule.size
+    : records.reduce((sum, eModule) => sum + eModule.size, 0);
 
   const hasCollapsedChildren = records.length > 1;
   const isFirstRecord = eModule.id === records[0].id;
@@ -143,12 +141,14 @@ function ModuleTableRow(props: TRProps) {
         {uniqueImports}
         {formatModuleName(eModule.name)}
       </td>
-      <td className="vert-align numeric">
-        <Unit bytes={eModule.cumulativeSize} />
-      </td>
-      <td className="vert-align numeric">
-        {moduleSize}
-      </td>
+      <Unit
+        elem='td'
+        className="vert-align numeric"
+        bytes={eModule.cumulativeSize} />
+      <Unit
+        elem='td'
+        className="vert-align numeric"
+        bytes={moduleSizeBytes} />
       <td className="vert-align numeric">
         <RequiredByPanelContainer eModule={eModule} />
       </td>

--- a/src/components/stats/ModuleTableHead.js
+++ b/src/components/stats/ModuleTableHead.js
@@ -33,7 +33,9 @@ export default function ModuleTableHead(props: Props) {
   return (
     <thead>
       <tr>
-        <th></th>
+        {process.env.REACT_APP_EXTERNAL_URL_PREFIX
+          ? <th></th>
+          : null}
         <th>
           <Button color="link" display="block" onClick={() => props.onSort('name')}>
             <div className="text-left">

--- a/src/components/stats/formatModuleName.js
+++ b/src/components/stats/formatModuleName.js
@@ -55,5 +55,5 @@ export default function formatModuleName(name: string) {
           {moduleName}
         </span>,
     ];
-  }).filter(_ => _).reduce(joinWithBR, []);
+  }).filter(Boolean).reduce(joinWithBR, []);
 }

--- a/src/types/__tests__/getRawStats.test.js
+++ b/src/types/__tests__/getRawStats.test.js
@@ -41,6 +41,22 @@ describe('getRawStats', () => {
       expect(console.warn).not.toHaveBeenCalled();
     });
 
+    it('should remove module.source fields from the typed dataset', () => {
+      const json = {
+        chunks: [],
+        modules: [
+          {source: 'hello world'},
+        ],
+      };
+
+      const stats = getStatsJson(json);
+      isRawStats(stats);
+      expect(stats).toEqual({
+        chunks: [],
+        modules: [{}],
+      });
+    });
+
     const failureModes = [
       {
         message: 'should throw when chunks is missing',

--- a/src/types/getRawStats.js
+++ b/src/types/getRawStats.js
@@ -39,6 +39,10 @@ export function getStatsJson(
   invariant(Array.isArray(json.chunks), `Found field 'chunks' but the value is not an array.`);
   invariant(Array.isArray(json.modules), `Found field 'modules' but the value is not an array.`);
 
+  json.modules.forEach((mod) => {
+    delete mod.source;
+  });
+
   return json;
 }
 

--- a/src/utils/__tests__/withTimings.test.js
+++ b/src/utils/__tests__/withTimings.test.js
@@ -1,0 +1,47 @@
+/**
+ * @flow
+ */
+
+import withTimings from '../withTimings';
+
+/* eslint-disable no-console */
+
+describe('withTimings', () => {
+  beforeEach(() => {
+    (console: any).timeStamp = jest.fn();
+    (console: any).time = jest.fn();
+    (console: any).timeEnd = jest.fn();
+  });
+
+  it('should proxy and call the method it wraps', () => {
+    const mock = jest.fn();
+
+    withTimings('scope', 'action')(mock, 'foo');
+
+    expect(mock).toHaveBeenCalledTimes(1);
+    expect(mock).toHaveBeenCalledWith('foo');
+  });
+
+  it('should call console.timeStamp around the method', () => {
+    const mock = jest.fn();
+
+    withTimings('Unittest', 'run')(mock, 'foo');
+
+    expect(console.timeStamp).toHaveBeenCalledTimes(2);
+    expect(console.timeStamp).toHaveBeenCalledWith('Unittest start: run');
+    expect(console.timeStamp).toHaveBeenCalledWith('Unittest end: run');
+  });
+
+  it('should call console.time to get a labelled duration', () => {
+    const mock = jest.fn();
+
+    withTimings('Unittest', 'run')(mock, 'foo');
+
+    expect(console.time).toHaveBeenCalledTimes(1);
+    expect(console.timeEnd).toHaveBeenCalledTimes(1);
+    expect(console.time).toHaveBeenCalledWith('Unittest: run');
+    expect(console.timeEnd).toHaveBeenCalledWith('Unittest: run');
+  });
+});
+
+/* eslint-enable no-console */

--- a/src/utils/reducer.js
+++ b/src/utils/reducer.js
@@ -14,6 +14,7 @@ import getEntryChunks from '../stats/getEntryChunks';
 import fullModuleData from '../stats/fullModuleData';
 import getCollapsableParentOf from '../stats/getCollapsableParentOf';
 import getModulesById from '../stats/getModulesById';
+import withTimings from './withTimings';
 
 export type Action =
   | {
@@ -372,8 +373,10 @@ export default function reducer(
   state: State = INITIAL_STATE,
   action: Action,
 ): State {
-  return calculateFullModuleData(
-    state,
-    handleAction(state, action)
+  return withTimings('Reducer', action.type)(() =>
+    calculateFullModuleData(
+      state,
+      handleAction(state, action)
+    )
   );
 }

--- a/src/utils/withTimings.js
+++ b/src/utils/withTimings.js
@@ -1,0 +1,18 @@
+/*
+ * @flow
+ */
+
+/* eslint-disable no-console */
+
+export default function withTimings(scope: string, action: string) {
+  return (fn: Function, ...args: Array<any>) => {
+    console.timeStamp(`${scope} start: ${action}`);
+    console.time(`${scope}: ${action}`);
+    const result = fn(...args);
+    console.timeEnd(`${scope}: ${action}`);
+    console.timeStamp(`${scope} end: ${action}`);
+    return result;
+  };
+}
+
+/* eslint-enable no-console */

--- a/yarn.lock
+++ b/yarn.lock
@@ -2457,6 +2457,10 @@ console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
 
+console-shim@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/console-shim/-/console-shim-1.0.3.tgz#d23509661e8ec1ec5fcf716891bf0263aee1ee78"
+
 constants-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/constants-browserify/-/constants-browserify-1.0.0.tgz#c20b96d8c617748aaf1c16021760cd27fcb8cb75"


### PR DESCRIPTION
Render optimizations to reduce extra dom nodes, remove too many document listeners, download glyphicons earlier, and remove the uploaded source from the redux store.