### PR TITLE
Fix recursion problem in getEntryHierarchy

### DIFF
--- a/src/components/FileSelectors.js
+++ b/src/components/FileSelectors.js
@@ -3,7 +3,7 @@
  */
 
 import type { ChunkID } from '../types/Stats';
-import type { Child } from '../stats/getEntryHeirarchy';
+import type { Child } from '../stats/getEntryHierarchy';
 import type { ItemValue } from './Bootstrap/DropdownList';
 
 import ChunkDropdown from './stats/ChunkDropdown';

--- a/src/components/stats/ChunkBreadcrumb.js
+++ b/src/components/stats/ChunkBreadcrumb.js
@@ -2,7 +2,7 @@
  * @flow
  */
 
-import type { Child } from '../../stats/getEntryHeirarchy';
+import type { Child } from '../../stats/getEntryHierarchy';
 
 import * as React from 'react';
 

--- a/src/components/stats/ChunkDropdown.js
+++ b/src/components/stats/ChunkDropdown.js
@@ -2,11 +2,11 @@
  * @flow
  */
 
-import type {Child} from '../../stats/getEntryHeirarchy';
+import type {Child} from '../../stats/getEntryHierarchy';
 import type {ChunkID} from '../../types/Stats';
 
 import { isSameChunk } from '../../types/Stats';
-import { flattenChunksByParent } from '../../stats/getEntryHeirarchy';
+import { flattenChunksByParent } from '../../stats/getEntryHierarchy';
 import Button from '../Bootstrap/Button';
 import DropdownList from '../Bootstrap/DropdownList';
 import * as React from 'react';

--- a/src/components/stats/__stories__/ChunkBreadcrumb.stories.js
+++ b/src/components/stats/__stories__/ChunkBreadcrumb.stories.js
@@ -7,7 +7,7 @@ import { storiesOf } from '@storybook/react';
 
 import { defaultChunk } from '../../../__test_helpers__/defaults';
 import ChunkBreadcrumb from '../ChunkBreadcrumb';
-import getEntryHeirarchy from '../../../stats/getEntryHeirarchy';
+import getEntryHierarchy from '../../../stats/getEntryHierarchy';
 import getParentChunks from '../../../stats/getParentChunks';
 
 const stats = {
@@ -30,7 +30,7 @@ const stats = {
   modules: [],
 };
 
-const chunksByParent = getEntryHeirarchy(stats);
+const chunksByParent = getEntryHierarchy(stats);
 
 storiesOf('ChunkBreadcrumb', module)
   .add('Empty data', () => (

--- a/src/stats/__tests__/__snapshots__/getEntryHierarchy.test.js.snap
+++ b/src/stats/__tests__/__snapshots__/getEntryHierarchy.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`getEntryHeirarchy should list all the chunks 1`] = `
+exports[`getEntryHierarchy should list all the chunks 1`] = `
 Object {
   "children": Array [
     Object {

--- a/src/stats/__tests__/getEntryHierarchy.test.js
+++ b/src/stats/__tests__/getEntryHierarchy.test.js
@@ -3,9 +3,9 @@
  */
 
 import {defaultChunk} from '../../__test_helpers__/defaults';
-import getEntryHeirarchy, {
+import getEntryHierarchy, {
   flattenChunksByParent,
-} from '../getEntryHeirarchy';
+} from '../getEntryHierarchy';
 
 const stats = {
   chunks: [
@@ -26,15 +26,15 @@ const stats = {
   modules: [],
 };
 
-describe('getEntryHeirarchy', () => {
+describe('getEntryHierarchy', () => {
   it('should list all the chunks', () => {
-    const result = getEntryHeirarchy(stats);
+    const result = getEntryHierarchy(stats);
 
     expect(result).toMatchSnapshot();
   });
 
   it('should flatten the list of all chunks', () => {
-    const result = flattenChunksByParent(getEntryHeirarchy(stats).children);
+    const result = flattenChunksByParent(getEntryHierarchy(stats).children);
 
     expect(result).toEqual([
       {id: 0, name: 'chunk-zero', indent: 0},

--- a/src/stats/__tests__/getParentChunks.test.js
+++ b/src/stats/__tests__/getParentChunks.test.js
@@ -2,7 +2,7 @@
  * @flow
  */
 
-import getEntryHeirarchy from '../getEntryHeirarchy';
+import getEntryHierarchy from '../getEntryHierarchy';
 import getParentChunks from '../getParentChunks';
 import {defaultChunk} from '../../__test_helpers__/defaults';
 
@@ -41,7 +41,7 @@ const stats = {
   modules: [],
 };
 
-const chunksByParent = getEntryHeirarchy(stats);
+const chunksByParent = getEntryHierarchy(stats);
 
 describe('getParentChunks', () => {
   it('should list some for a chunk in the middle', () => {

--- a/src/stats/chunkSizes.js
+++ b/src/stats/chunkSizes.js
@@ -7,7 +7,7 @@ import type { ChunkID, RawStats } from '../types/Stats';
 import getChunkModules from './getChunkModules';
 import getChunkName from './getChunkName';
 import getChunkNamesFromImportedModules from './getChunkNamesFromImportedModules';
-import getEntryHeirarchy from './getEntryHeirarchy';
+import getEntryHierarchy from './getEntryHierarchy';
 import getParentChunks from './getParentChunks';
 import invariant from 'invariant';
 
@@ -22,7 +22,7 @@ export default function chunkSizes(
   rawStats: Array<RawStats>,
 ): Array<Array<ChunkSize>> {
   return rawStats.map((stats) => {
-    const chunksByParent = getEntryHeirarchy(stats);
+    const chunksByParent = getEntryHierarchy(stats);
     const importedChunkNames = getChunkNamesFromImportedModules(stats);
 
     return stats.chunks.map((chunk) => {

--- a/src/stats/fullModuleData.js
+++ b/src/stats/fullModuleData.js
@@ -9,10 +9,10 @@ import type {
   RawStats,
 } from '../types/Stats';
 
-import type {Child} from './getEntryHeirarchy';
+import type {Child} from './getEntryHierarchy';
 
 import getChunkModules from './getChunkModules';
-import getEntryHeirarchy from './getEntryHeirarchy';
+import getEntryHierarchy from './getEntryHierarchy';
 import getExtendedModulesById, {calculateModuleSizes} from './getExtendedModulesById';
 import getModulesById from './getModulesById';
 import getParentChunks from './getParentChunks';
@@ -33,7 +33,7 @@ export default function fullModuleData(
   selectedChunkId: ?ChunkID,
   blacklistedModuleIds: Array<ModuleID>,
 ): FullModuleDataType {
-  const chunksByParent = getEntryHeirarchy(stats);
+  const chunksByParent = getEntryHierarchy(stats);
 
   if (selectedChunkId === null || selectedChunkId === undefined) {
     return {

--- a/src/stats/getChunkModules.js
+++ b/src/stats/getChunkModules.js
@@ -4,7 +4,7 @@
 
 import type {RawStats, Module} from '../types/Stats';
 
-import type {Child} from './getEntryHeirarchy';
+import type {Child} from './getEntryHierarchy';
 
 import getModulesByChunk from './getModulesByChunk';
 

--- a/src/stats/getEntryHierarchy.js
+++ b/src/stats/getEntryHierarchy.js
@@ -22,57 +22,78 @@ export type FlatChunk = {
   indent: number,
 };
 
-function getChildrenForChunk(
-  stats,
-  importedChunkNames,
-  parentChunk,
-  existingParents: Array<ChunkID>,
-): Array<Child> {
-  return getEntryChunks(stats)
-    .filter((chunk) =>
-      chunk.parents.includes(parentChunk.id) &&
-      !existingParents.includes(chunk.id)
-    )
-    .map((chunk) => ({
-      id: chunk.id,
-      ids: [chunk.id],
-      name: getChunkName(chunk, importedChunkNames),
-      names: chunk.names,
-      children: getChildrenForChunk(
-        stats,
-        importedChunkNames,
-        chunk,
-        existingParents.concat(chunk.id),
-      ),
-    }));
-}
-
 export const ROOT_ID = Number.MIN_SAFE_INTEGER;
+
+function getSyncName(name: string): string {
+  if (name.indexOf('./node_modules/promise-loader?') === 0) {
+    return name.replace('./node_modules/promise-loader?', '');
+  } else {
+    const match = name.match(/import\('([\w\S]+)'\)/);
+    if (match) {
+      return match[1];
+    } else {
+      return name;
+    }
+  }
+}
 
 export default function getEntryHierarchy(
   stats: RawStats,
 ): Child {
   const importedChunkNames = getChunkNamesFromImportedModules(stats);
+  const entryChunks = getEntryChunks(stats);
+
+  const rootChunks = [];
+  const chunksById = {};
+  const asyncChunksById = {};
+  entryChunks.forEach((chunk) => {
+    const name = getChunkName(chunk, importedChunkNames);
+    chunksById[chunk.id] = {
+      id: chunk.id,
+      ids: [chunk.id],
+      name: name,
+      names: chunk.names,
+      children: [],
+    };
+
+    const syncName = getSyncName(name);
+    if (syncName !== name) {
+      asyncChunksById[chunk.id] = {
+        id: chunk.id,
+        ids: [chunk.id],
+        name: getChunkName(chunk, importedChunkNames),
+        names: chunk.names,
+        children: [],
+      };
+    }
+  });
+
+  entryChunks.forEach((chunk) => {
+    const id = chunk.id;
+    const child = chunksById[id];
+    if (chunk.parents.length === 0) {
+      rootChunks.push(child);
+    } else {
+      chunk.parents.forEach((parentId) => {
+        const parent = chunksById[parentId];
+        const asyncParent = asyncChunksById[parentId];
+
+        if (asyncParent) {
+          asyncParent.children.push(child);
+        } else {
+          parent.children.push(child);
+        }
+      });
+    }
+  });
 
   return {
     id: ROOT_ID,
     ids: [],
     name: '',
     names: [],
-    children: getEntryChunks(stats)
-      .filter((chunk) => chunk.parents.length === 0)
-      .map((chunk) => ({
-        id: chunk.id,
-        ids: [chunk.id],
-        name: getChunkName(chunk, importedChunkNames),
-        names: chunk.names,
-        children: getChildrenForChunk(
-          stats,
-          importedChunkNames,
-          chunk,
-          [chunk.id],
-        ),
-      })),
+    // $FlowFixMe: Object.values has an Array<mixed> here
+    children: rootChunks.concat(Object.values(asyncChunksById)),
   };
 }
 

--- a/src/stats/getEntryHierarchy.js
+++ b/src/stats/getEntryHierarchy.js
@@ -49,7 +49,7 @@ function getChildrenForChunk(
 
 export const ROOT_ID = Number.MIN_SAFE_INTEGER;
 
-export default function getEntryHeirarchy(
+export default function getEntryHierarchy(
   stats: RawStats,
 ): Child {
   const importedChunkNames = getChunkNamesFromImportedModules(stats);

--- a/src/stats/getParentChunks.js
+++ b/src/stats/getParentChunks.js
@@ -3,10 +3,10 @@
  */
 
 import type {ChunkID} from '../types/Stats';
-import type {Child} from './getEntryHeirarchy';
+import type {Child} from './getEntryHierarchy';
 
 import {isSameChunk} from '../types/Stats';
-import {ROOT_ID} from './getEntryHeirarchy';
+import {ROOT_ID} from './getEntryHierarchy';
 
 function findChunk(
   root: Child,


### PR DESCRIPTION
There was a recursive error were would would iterate through cyclic modules references and lockup the window before crashing. This uses an iterative approach to assign references to the existing objects, instead of building a new tree of objects and assigning references forever. 

Also fix spelling