### PR TITLE
Update flow-coverage-report config field names

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,14 +111,14 @@
   },
   "flow-coverage-report": {
     "threshold": 85,
-    "type": [
+    "reportTypes": [
       "html",
       "text"
     ],
-    "includeGlob": [
+    "globIncludePatterns": [
       "src/**/*.js"
     ],
-    "excludeGlob": [
+    "globExcludePatterns": [
       "+(node_modules|build|flow-typed)/**/*.js",
       "src/components/__tests__/Storyshots.test.js"
     ]


### PR DESCRIPTION
Stomp some warnings about deprecated field names from flow-coverage-report

Warnings removed from cli:
```
WARN: "includeGlob" config file property has been renamed to "globIncludePatterns"
WARN: "excludeGlob" config file property has been renamed to "globExcludePatterns"
WARN: "type" config file property has been renamed to "reportTypes"
```